### PR TITLE
Initial Rune Factory games support

### DIFF
--- a/lib/AuroraLip/Archives/ArchiveFile.cs
+++ b/lib/AuroraLip/Archives/ArchiveFile.cs
@@ -90,7 +90,7 @@ namespace AuroraLip.Archives
         }
 
         /// <inheritdoc />
-        public override string ToString() => $"{Name} [0x{FileData.Length:X8}]";
+        public override string ToString() => $"{Name} {FileData.ToString()}";
 
         //=====================================================================
 

--- a/lib/AuroraLip/Archives/Formats/FBTI.cs
+++ b/lib/AuroraLip/Archives/Formats/FBTI.cs
@@ -1,0 +1,57 @@
+﻿using AuroraLip.Common;
+using System;
+using System.IO;
+
+namespace AuroraLip.Archives.Formats
+{
+    // Rune Factory (Frontier) archive format
+    public class FBTI : Archive, IMagicIdentify, IFileAccess
+    {
+        public bool CanRead => true;
+
+        public bool CanWrite => false;
+
+        public string Magic => magic;
+
+        private const string magic = "FBTI";
+
+        public FBTI() { }
+
+        public FBTI(string filename) : base(filename) { }
+
+        public FBTI(Stream stream, string filename = null) : base(stream, filename) { }
+
+        public bool IsMatch(Stream stream, in string extension = "")
+            => stream.MatchString(magic);
+
+        protected override void Read(Stream stream)
+        {
+            if (!stream.MatchString(magic))
+                throw new Exception($"Invalid Identifier. Expected \"{Magic}\"");
+            string version = stream.ReadString(4);
+            uint file_count = stream.ReadUInt32(Endian.Big);
+            uint unknown = stream.ReadUInt32(Endian.Big);
+
+            Root = new ArchiveDirectory() { OwnerArchive = this };
+            for (uint i = 0; i < file_count; i++)
+            {
+                uint file_offset = stream.ReadUInt32(Endian.Big);
+                uint size = stream.ReadUInt32(Endian.Big);
+                long saved_position = stream.Position;
+
+                ArchiveFile Sub = new ArchiveFile() { Parent = Root, Name = i.ToString() };
+                stream.Seek(file_offset, SeekOrigin.Begin);
+                Sub.FileData = new SubStream(stream, size);
+                Root.Items.Add(Sub.Name, Sub);
+
+                // Read the file, move on to the next one
+                stream.Seek(saved_position, SeekOrigin.Begin);
+            }
+        }
+
+        protected override void Write(Stream ArchiveFile)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/lib/AuroraLip/Archives/Formats/NLCM.cs
+++ b/lib/AuroraLip/Archives/Formats/NLCM.cs
@@ -1,0 +1,75 @@
+﻿using AuroraLip.Common;
+using System;
+using System.IO;
+
+namespace AuroraLip.Archives.Formats
+{
+    // Rune Factory (Frontier) archive format
+    // Cross-referenced with https://github.com/master801/Rune-Factory-Frontier-Tools
+    public class NLCM : Archive, IMagicIdentify, IFileAccess
+    {
+        public bool CanRead => true;
+
+        public bool CanWrite => false;
+
+        public string Magic => magic;
+
+        private const string magic = "NLCM";
+
+        private FileStream reference_stream;
+
+        public NLCM() { }
+
+        public NLCM(string filename) : base(filename) { }
+
+        public NLCM(Stream stream, string filename = null) : base(stream, filename) { }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+            {
+                if (reference_stream != null)
+                {
+                    reference_stream.Dispose();
+                }
+            }
+        }
+
+        public bool IsMatch(Stream stream, in string extension = "")
+            => stream.MatchString(magic);
+
+        protected override void Read(Stream stream)
+        {
+            if (!stream.MatchString(magic))
+                throw new Exception($"Invalid Identifier. Expected \"{Magic}\"");
+            uint table_offset = stream.ReadUInt32(Endian.Big);
+            uint unknown2 = stream.ReadUInt32(Endian.Big);
+            uint file_count = stream.ReadUInt32(Endian.Big);
+            uint unknown3 = stream.ReadUInt32(Endian.Big);
+            string reference_file = Path.Combine(Directory.GetParent(((System.IO.FileStream)stream).Name).FullName, stream.ReadString());
+            stream.Seek(table_offset, SeekOrigin.Begin);
+            reference_stream = new FileStream(reference_file,
+                       FileMode.Open, FileAccess.Read, FileShare.Read);
+
+            Root = new ArchiveDirectory() { OwnerArchive = this };
+            for (uint i = 0; i < file_count; i++)
+            {
+                uint size = stream.ReadUInt32(Endian.Big);
+                uint padding = stream.ReadUInt32(Endian.Big);
+                uint file_offset = stream.ReadUInt32(Endian.Big);
+                uint padding2 = stream.ReadUInt32(Endian.Big);
+
+                ArchiveFile Sub = new ArchiveFile() { Parent = Root, Name = i.ToString() };
+                reference_stream.Seek(file_offset, SeekOrigin.Begin);
+                Sub.FileData = new SubStream(reference_stream, size);
+                Root.Items.Add(Sub.Name, Sub);
+            }
+        }
+
+        protected override void Write(Stream ArchiveFile)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/lib/AuroraLip/AuroraLip.csproj
+++ b/lib/AuroraLip/AuroraLip.csproj
@@ -70,7 +70,9 @@
     <Compile Include="Archives\ArchiveFile.cs" />
     <Compile Include="Archives\Formats\bres.cs" />
     <Compile Include="Archives\Formats\FBC.cs" />
+    <Compile Include="Archives\Formats\FBTI.cs" />
     <Compile Include="Archives\Formats\NARC.cs" />
+    <Compile Include="Archives\Formats\NLCM.cs" />
     <Compile Include="Archives\Formats\PCKG.cs" />
     <Compile Include="Archives\Formats\RARC.cs" />
     <Compile Include="Archives\Formats\RKV2.cs" />
@@ -117,6 +119,7 @@
     <Compile Include="Palette\Formats\PLT0.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Texture\Formats\BTI.cs" />
+    <Compile Include="Texture\Formats\HXTB.cs" />
     <Compile Include="Texture\Formats\PTLG.cs" />
     <Compile Include="Texture\Formats\TEX.cs" />
     <Compile Include="Texture\Formats\TXTR.cs" />

--- a/lib/AuroraLip/Common/FormatDictionary_List.cs
+++ b/lib/AuroraLip/Common/FormatDictionary_List.cs
@@ -217,6 +217,11 @@ namespace AuroraLip.Common
             new FormatInfo(".vol", "RTDP", FormatType.Archive, "Arc Rise Archive", "Imageepoch"),
             new FormatInfo(".wtm", "WTMD", FormatType.Texture, "Arc Rise Texture", "Imageepoch"),
 
+            // Neverland
+            new FormatInfo(".bin", "FBTI", FormatType.Archive, "Rune Factory Archive", "Neverland"),
+            new FormatInfo(".bin", "NLCM", FormatType.Archive, "Rune Factory Archive", "Neverland"),
+            new FormatInfo(".hvt", "HXTB", FormatType.Texture, "Rune Factory Texture", "Neverland"),
+
             //Treasure
             new FormatInfo(".RSC", FormatType.Archive, "Wario World archive", "Treasure"),
             new FormatInfo(".arc", "NARC", FormatType.Archive, "Sin and Punishment archive", "Treasure"),
@@ -247,8 +252,6 @@ namespace AuroraLip.Common
             new FormatInfo(".pos","POSD", FormatType.Else, "Rune Factory FREB Archive Info"),
             new FormatInfo(".fsys","FSYS", FormatType.Archive, "Pokemon"), //https://projectpokemon.org/home/tutorials/rom/stars-pok%C3%A9mon-colosseum-and-xd-hacking-tutorial/part-1-file-decompression-and-recompression-r5/
             new FormatInfo(".asr","AsuraZlb", FormatType.Archive, "Rebellion"),
-            new FormatInfo(".dat","FBTI0001", FormatType.Archive, "Rune Factory"),
-            new FormatInfo(".bin","NLCM", FormatType.Else, "Rune Factory Archive Info"),
             new FormatInfo(".ftx", "FCMP", FormatType.Archive, "MURAMASA"),// compressed MURAMASA: THE DEMON BLADE |.ftx|FCMP FTEX||.mbs|FCMP FMBS||.nms|FCMP NMSB||.nsb|FCMP NSBD|Skript Data||.esb|FCMP EMBP||.abf|FCMP MLIB|
             new FormatInfo(".dict", new byte[]{169,243,36,88,6,1},0, FormatType.Archive),
             new FormatInfo(".dat", "AKLZ~?Qd=ÌÌÍ", FormatType.Archive,"Skies of Arcadia Legends"),

--- a/lib/AuroraLip/Common/SubStream.cs
+++ b/lib/AuroraLip/Common/SubStream.cs
@@ -123,6 +123,8 @@ namespace AuroraLip.Common
             Position += count;
         }
 
+        public override string ToString() => $"[0x{Offset:X8}] [0x{Length:X8}]";
+
         #region Dispose
         protected override void Dispose(bool disposing)
         {

--- a/lib/AuroraLip/Texture/Formats/HXTB.cs
+++ b/lib/AuroraLip/Texture/Formats/HXTB.cs
@@ -1,0 +1,92 @@
+﻿using AuroraLip.Common;
+using AuroraLip.Texture.J3D;
+using System;
+using System.IO;
+using static AuroraLip.Texture.J3D.JUtility;
+
+namespace AuroraLip.Texture.Formats
+{
+    // Rune Factory (Frontier) texture format
+    public class HXTB : JUTTexture, IMagicIdentify, IFileAccess
+    {
+        public bool CanRead => true;
+
+        public bool CanWrite => false;
+
+        public string Magic => magic;
+
+        private const string magic = "HXTB";
+
+        public HXTB() { }
+
+        public HXTB(Stream stream) : base(stream) { }
+
+        public HXTB(string filepath) : base(filepath) { }
+
+        public bool IsMatch(Stream stream, in string extension = "")
+            => stream.MatchString(magic);
+
+        protected override void Read(Stream stream)
+        {
+            if (!stream.MatchString(magic))
+                throw new Exception($"Invalid Identifier. Expected \"{Magic}\"");
+
+            string version = stream.ReadString(4);
+            uint name_table_offset = stream.ReadUInt32(Endian.Big);
+            uint file_count = stream.ReadUInt32(Endian.Big);
+            // File size and other data after this
+            for (uint i = 0; i < file_count; i++)
+            {
+                stream.Seek(name_table_offset + i * 0x20, SeekOrigin.Begin);
+                string name = stream.ReadString(16);
+                uint unknown = stream.ReadUInt32(Endian.Big);
+                uint header_offset = stream.ReadUInt32(Endian.Big);
+                uint palette_header_offset = stream.ReadUInt32(Endian.Big);
+                stream.Seek(header_offset, SeekOrigin.Begin);
+                uint data_offset = stream.ReadUInt32(Endian.Big);
+                GXImageFormat format = (GXImageFormat)stream.ReadByte();
+                byte mipmaps = (byte)stream.ReadByte();
+                ushort unknown3 = stream.ReadUInt16(Endian.Big);
+                ushort width = stream.ReadUInt16(Endian.Big);
+                ushort height = stream.ReadUInt16(Endian.Big);
+                uint size = stream.ReadUInt32(Endian.Big);
+
+                byte[] palette_data = null;
+                GXPaletteFormat palette_format = GXPaletteFormat.IA8;
+                uint palette_count = 0;
+                if (palette_header_offset > 0)
+                {
+                    stream.Seek(palette_header_offset, SeekOrigin.Begin);
+                    uint palette_data_offset = stream.ReadUInt32(Endian.Big);
+                    palette_format = (GXPaletteFormat)stream.ReadByte();
+                    ushort palette_unknown = stream.ReadUInt16(Endian.Big);
+                    ushort palette_unknown2 = stream.ReadUInt16(Endian.Big);
+                    uint palette_unknown3 = stream.ReadUInt32(Endian.Big);
+                    uint palette_size = stream.ReadUInt32(Endian.Big);
+                    palette_count = palette_size / 2;
+                    stream.Seek(palette_data_offset, SeekOrigin.Begin);
+                    palette_data = stream.Read((int)palette_size, Endian.Little);
+                }
+
+                stream.Seek(data_offset, SeekOrigin.Begin);
+                TexEntry current = new TexEntry(stream, palette_data, format, palette_format, (int)palette_count, width, height, mipmaps)
+                {
+                    LODBias = 0,
+                    MagnificationFilter = GXFilterMode.Nearest,
+                    MinificationFilter = GXFilterMode.Nearest,
+                    WrapS = GXWrapMode.CLAMP,
+                    WrapT = GXWrapMode.CLAMP,
+                    EnableEdgeLOD = false,
+                    MinLOD = 0,
+                    MaxLOD = 0
+                };
+                Add(current);
+            }
+        }
+
+        protected override void Write(Stream stream)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Requires non-multithreaded option to be turned on.  Supports both Tides of Destiny and Frontier.  I'm sure there is more that can be done (the official texture pack for Frontier has ~5000 textures while this has ~3500 and Tides is missing all its town textures).  Still a good first step!