### PR TITLE
Better linebreak functionality, cleaner outputs

### DIFF
--- a/TextureExtraction tool/Data/Logger.cs
+++ b/TextureExtraction tool/Data/Logger.cs
@@ -37,19 +37,19 @@ namespace DolphinTextureExtraction_tool
 
         private void WriteHeader()
         {
-            WriteLine("".PadLeft(64, '-'));
+            WriteLine(StringEx.Divider(64));
             WriteLine($"{System.Diagnostics.Process.GetCurrentProcess().ProcessName} {IntPtr.Size * 8}bit v{System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}  {DateTime.Now}");
-            WriteLine("".PadLeft(64, '-'));
+            WriteLine(StringEx.Divider(64));
             Flush();
         }
 
         public void WriteFoot(ScanBase.Results result)
         {
-            WriteLine("".PadLeft(64, '-'));
+            WriteLine(StringEx.Divider(64));
             WriteLine($"~END  {DateTime.Now}");
-            WriteLine("".PadLeft(64, '-'));
-            WriteLine(result.ToString());
-            WriteLine("".PadLeft(64, '-'));
+            WriteLine(StringEx.Divider(64));
+            WriteLine(result.ToString().LineBreak(120, 20));
+            WriteLine(StringEx.Divider(64));
             Flush();
         }
 
@@ -61,10 +61,10 @@ namespace DolphinTextureExtraction_tool
         {
             lock (LockFile)
             {
-                WriteLine("".PadLeft(64, '-'));
+                WriteLine(StringEx.Divider(64));
                 WriteLine($"Exception: {strMessage} {ex?.Message}");
                 WriteLine($"{ex?.Source}:{ex?.StackTrace}");
-                WriteLine("".PadLeft(64, '-'));
+                WriteLine(StringEx.Divider(64));
                 Flush();
             }
             Console.Error.WriteLine($"Exception: {strMessage} {ex?.Message}");

--- a/TextureExtraction tool/Data/TextureExtractor.cs
+++ b/TextureExtraction tool/Data/TextureExtractor.cs
@@ -99,9 +99,9 @@ namespace DolphinTextureExtraction_tool
                 StringBuilder sb = new StringBuilder();
                 sb.AppendLine($"Extracted textures: {Extracted}");
                 sb.AppendLine($"Unsupported files: {Unsupported}");
-                if (Unsupported != 0) sb.AppendLine($"Unsupported files Typs: {string.Join(", ", UnsupportedFormatType.Select(x => x.GetFullDescription()))}".LineBreak(108, "\n                  "));
+                if (Unsupported != 0) sb.AppendLine($"Unsupported files Typs: {string.Join(", ", UnsupportedFormatType.Select(x => x.GetFullDescription()))}");
                 sb.AppendLine($"Unknown files: {Unknown}");
-                if (UnknownFormatType.Count != 0) sb.AppendLine($"Unknown files Typs: {string.Join(", ", UnknownFormatType.Select(x => x.Header == null || x.Header.MagicASKI.Length < 2 ? x.Extension : $"{x.Extension} \"{x.Header.MagicASKI}\""))}".LineBreak(108, "\n                  "));
+                if (UnknownFormatType.Count != 0) sb.AppendLine($"Unknown files Typs: {string.Join(", ", UnknownFormatType.Select(x => x.Header == null || x.Header.MagicASKI.Length < 2 ? x.Extension : $"{x.Extension} \"{x.Header.MagicASKI}\""))}");
                 sb.AppendLine($"Extraction rate: ~ {GetExtractionSize()}");
                 sb.AppendLine($"Scan time: {TotalTime.TotalSeconds:.000}s");
                 return sb.ToString();

--- a/TextureExtraction tool/Data/Unpack.cs
+++ b/TextureExtraction tool/Data/Unpack.cs
@@ -65,7 +65,7 @@ namespace DolphinTextureExtraction_tool
             if (FormatTypee.Header == null || FormatTypee.Header?.Magic.Length <= 3)
             {
                 Log.Write(FileAction.Unknown, file + $" ~{MathEx.SizeSuffix(stream.Length, 2)}",
-                    $"Bytes32:[{string.Join(",", stream.Read(32))}]");
+                    $"Bytes32:[{BitConverter.ToString(stream.Read(32))}]");
             }
             else
             {

--- a/TextureExtraction tool/Program.cs
+++ b/TextureExtraction tool/Program.cs
@@ -212,12 +212,12 @@ namespace DolphinTextureExtraction_tool
                     case "format":
                     case "f":
                         #region formats
-                        ConsoleEx.WriteLineColoured("".PadLeft(108, '-'), ConsoleColor.Blue);
+                        ConsoleEx.WriteLineColoured(StringEx.Divider(), ConsoleColor.Blue);
                         Console.WriteLine($"Known formats: {FormatDictionary.Master.Length}.");
-                        ConsoleEx.WriteLineColoured("".PadLeft(108, '-'), ConsoleColor.Blue);
+                        ConsoleEx.WriteLineColoured(StringEx.Divider(), ConsoleColor.Blue);
                         foreach (var item in FormatDictionary.Master)
                             Console.WriteLine($"{item.GetFullDescription()} Typ:{item.Typ}");
-                        ConsoleEx.WriteLineColoured("".PadLeft(108, '-'), ConsoleColor.Blue);
+                        ConsoleEx.WriteLineColoured(StringEx.Divider(), ConsoleColor.Blue);
                         #endregion
                         break;
                     case "cut":
@@ -444,7 +444,7 @@ namespace DolphinTextureExtraction_tool
 
         static void PrintHeader()
         {
-            ConsoleEx.WriteLineColoured("".PadLeft(108, '-'), ConsoleColor.Blue);
+            ConsoleEx.WriteLineColoured(StringEx.Divider(), ConsoleColor.Blue);
             Console.ForegroundColor = ConsoleColor.Cyan;
 #if DEBUG
             Console.WriteLine($"{System.Diagnostics.Process.GetCurrentProcess().ProcessName} v{System.Reflection.Assembly.GetExecutingAssembly().GetName().Version} {IntPtr.Size * 8}bit\t\t{DateTime.Now.ToString()}\t\t*DEBUG");
@@ -452,7 +452,7 @@ namespace DolphinTextureExtraction_tool
             Console.WriteLine($"{System.Diagnostics.Process.GetCurrentProcess().ProcessName} v{System.Reflection.Assembly.GetExecutingAssembly().GetName().Version} {IntPtr.Size * 8}bit\t\t{DateTime.Now.ToString()}");
 #endif
             PrintFormats();
-            ConsoleEx.WriteLineColoured("".PadLeft(108, '-'), ConsoleColor.Blue);
+            ConsoleEx.WriteLineColoured(StringEx.Divider(), ConsoleColor.Blue);
             ConsoleEx.WriteColoured("INFO:", ConsoleColor.Red);
             Console.WriteLine(" currently no ROM images are supported, Please unpack them with dolphin into a folder.");
             Console.WriteLine("right click on a game -> Properties -> Filesystem -> right click on \"Disc - [Game ID]\" -> Extract Files...");
@@ -468,7 +468,7 @@ namespace DolphinTextureExtraction_tool
             formats.Add("BMD3");
             formats.Add("TEX1");
             formats.Sort();
-            Console.WriteLine($"Supported formats: {string.Join(", ", formats)}.".LineBreak(108, "\n                  "));
+            Console.WriteLine($"Supported formats: {string.Join(", ", formats)}.".LineBreak(20));
         }
 
         static void PrintOptions(TextureExtractor.ExtractorOptions options)
@@ -491,10 +491,10 @@ namespace DolphinTextureExtraction_tool
 
         static void PrintResult(TextureExtractor.ExtractorResult result)
         {
-            ConsoleEx.WriteLineColoured("".PadLeft(108, '-'), ConsoleColor.Blue);
-            Console.WriteLine(result.ToString());
+            ConsoleEx.WriteLineColoured(StringEx.Divider(), ConsoleColor.Blue);
+            Console.WriteLine(result.ToString().LineBreak(20));
             Console.WriteLine($"Log saved: \"{result.LogFullPath}\"");
-            ConsoleEx.WriteLineColoured("".PadLeft(108, '-'), ConsoleColor.Blue);
+            ConsoleEx.WriteLineColoured(StringEx.Divider(), ConsoleColor.Blue);
         }
 
         private static ConsoleBar ScanProgress;

--- a/lib/AuroraLip/Common/Extensions/StringEx.cs
+++ b/lib/AuroraLip/Common/Extensions/StringEx.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 using System.Runtime.InteropServices;
 
 namespace AuroraLip.Common
@@ -15,22 +16,67 @@ namespace AuroraLip.Common
         public static string SimpleDate => DateTime.Now.ToString("yy-MM-dd_HH-mm-ss");
 
         /// <summary>
-        /// Introduces a linebreak if a certain threshold is passed
+        /// Introduces a linebreak if the current console's width is passed
+        /// </summary>
+        public static string LineBreak(this string text) => text.LineBreak(Console.WindowWidth - 1, 0);
+
+        /// <summary>
+        /// Introduces a linebreak if the current console's width is passed, prepending a given <paramref name="offset"/> of space characters
         /// </summary>
         /// <param name="max">The maximum number of characters to a line.</param>
-        /// <param name="insert">What to prepend to any created newlines.</param>
-        /// <returns></returns>
-        public static string LineBreak(this string str, int max, in string insert)
+        public static string LineBreak(this string text, int offset) => text.LineBreak(Console.WindowWidth - 1, offset);
+
+        /// <summary>
+        /// Introduces a linebreak if the specified <paramref name="width"/> is passed, prepending a given <paramref name="offset"/> of space characters
+        /// </summary>
+        /// <param name="width">The maximum number of characters to a line.</param>
+        /// <param name="offset">How many spaces to prepend to any created newlines.</param>
+        public static string LineBreak(this string text, int width, int offset)
         {
-            int Index = 0;
-            while (Index + max < str.Length)
+            if (string.IsNullOrEmpty(text)) return string.Empty;
+            string insert = Environment.NewLine.PadRight(offset, ' ');
+            StringBuilder output = new StringBuilder();
+            StringReader reader = new StringReader(text);
+            while(true)
             {
-                ReadOnlySpan<char> line = str.AsSpan(Index, max);
-                Index += line.LastIndexOf(' ');
-                str = str.Insert(Index, insert);
+                string read = reader.ReadLine();
+                if (read == null) break;
+                int index = 0;
+                while (index + width < read.Length)
+                {
+                    ReadOnlySpan<char> line = read.AsSpan(index, width);
+                    index += line.LastIndexOf(' ');
+                    read = read.Insert(index, insert);
+                }
+                output.AppendLine(read);
             }
-            return str;
+            output.Length -= Environment.NewLine.Length;
+            return output.ToString();
         }
+
+        /// <summary>
+        /// Creates a divider line equal to the current console's width
+        /// </summary>
+        public static string Divider() => Divider(Console.WindowWidth - 1, '-');
+
+        /// <summary>
+        /// Creates a divider line to the specified <paramref name="width"/>
+        /// </summary>
+        /// <param name="width">How long the divider should be</param>
+        public static string Divider(int width) => Divider(width, '-');
+
+        /// <summary>
+        /// Creates a divider line equal to the current console's width using the specified <paramref name="divider"/>
+        /// </summary>
+        /// <param name="divider">What character should make up the divider</param>
+        public static string Divider(char divider) => Divider(Console.WindowWidth - 1, divider);
+
+        /// <summary>
+        /// Creates a divider line using the specified <paramref name="width"/> &amp; <paramref name="divider"/>
+        /// </summary>
+        /// <param name="width">How long the divider should be</param>
+        /// <param name="divider">What character should make up the divider</param>
+        public static string Divider(int width, char divider) => string.Empty.PadRight(width, divider);
 
         public static string Combine(in ReadOnlySpan<char> path, in ReadOnlySpan<char> path2)
         {


### PR DESCRIPTION
- Linebreaks can now be handled for a string or string collection as a whole, even one that already has newlines
- By default linebreaks now reference the console's window width minus one for when to add a newline
- TextureExtractor's ToString itself now formatted to linebreaks, rather than being individually applied internally
- Divider method added, also by default checks console's width minus one for length 
- Added BitConverter format change I missed before