### PR TITLE
GetFullType method added to FormatInfo

### DIFF
--- a/TextureExtraction tool/Data/TextureExtractor.cs
+++ b/TextureExtraction tool/Data/TextureExtractor.cs
@@ -89,7 +89,7 @@ namespace DolphinTextureExtraction_tool
                 sb.AppendLine($"Unsupported files: {Unsupported}");
                 if (Unsupported != 0) sb.AppendLine($"Unsupported files Typs: {string.Join(", ", UnsupportedFormatType.Select(x => x.GetFullDescription()))}");
                 sb.AppendLine($"Unknown files: {Unknown}");
-                if (UnknownFormatType.Count != 0) sb.AppendLine($"Unknown files Typs: {string.Join(", ", UnknownFormatType.Select(x => x.Header == null || x.Header.MagicASKI.Length < 2 ? x.Extension : $"{x.Extension} \"{x.Header.MagicASKI}\""))}");
+                if (UnknownFormatType.Count != 0) sb.AppendLine($"Unknown files Typs: {string.Join(", ", UnknownFormatType.Select(x => x.GetFullType()))}");
                 sb.AppendLine($"Extraction rate: ~ {GetExtractionSize()}");
                 sb.AppendLine($"Scan time: {TotalTime.TotalSeconds:.000}s");
                 return sb.ToString();

--- a/lib/AuroraLip/Common/FormatInfo.cs
+++ b/lib/AuroraLip/Common/FormatInfo.cs
@@ -86,6 +86,12 @@ namespace AuroraLip.Common
                 return (Developer != "" ? Developer + ' ' : "") + Extension + ' ' + Description;
         }
 
+        public string GetFullType()
+        {
+            return (Header == null || Header.MagicASKI.Length < 2) ? Extension :
+                Extension + (Extension != "" ? " " : "") + Header.MagicASKI;
+        }
+
         public virtual bool Equals(FormatInfo other)
         {
             if (Header != null)


### PR DESCRIPTION
Cleans up ToString method in TextureExtractor & ensures that headers without a file extension won't have an extra space character prepended