### PR TITLE
Fix duplicate keys causing errors when reading contents of BRRES archives

### DIFF
--- a/lib/AuroraLip/Archives/Formats/bres.cs
+++ b/lib/AuroraLip/Archives/Formats/bres.cs
@@ -88,7 +88,10 @@ namespace AuroraLip.Archives.Formats
                             if (Magic != "RASD" && FileSize <= stream.Length - stream.Position)
                             {
                                 Sub.FileData = new ArchiveFile.ArchiveFileStream(stream, FileSize) { Parent = Sub };
-                                ParentDirectory.Items.Add(Sub.Name, Sub);
+                                if (!ParentDirectory.Items.ContainsKey(Sub.Name))
+                                {
+                                    ParentDirectory.Items.Add(Sub.Name, Sub);
+                                }
                             }
                         }
                         else
@@ -96,7 +99,10 @@ namespace AuroraLip.Archives.Formats
                             stream.Seek(StartOfGroup + DataPointer, SeekOrigin.Begin);
                             ArchiveDirectory Sub = new ArchiveDirectory(this, ParentDirectory) { Name = Name };
                             ReadIndex(stream, EndOfRoot, Sub);
-                            ParentDirectory.Items.Add(Sub.Name, Sub);
+                            if (!ParentDirectory.Items.ContainsKey(Sub.Name))
+                            {
+                                ParentDirectory.Items.Add(Sub.Name, Sub);
+                            }
                         }
                     }
                 }

--- a/lib/AuroraLip/Archives/Formats/bres.cs
+++ b/lib/AuroraLip/Archives/Formats/bres.cs
@@ -107,10 +107,18 @@ namespace AuroraLip.Archives.Formats
                             stream.Seek(StartOfGroup + DataPointer, SeekOrigin.Begin);
                             ArchiveDirectory Sub = new ArchiveDirectory(this, ParentDirectory) { Name = Name };
                             ReadIndex(stream, EndOfRoot, Sub);
-                            if (!ParentDirectory.Items.ContainsKey(Sub.Name))
+                            if (ParentDirectory.Items.ContainsKey(Sub.Name))
                             {
-                                ParentDirectory.Items.Add(Sub.Name, Sub);
+                                for (int n = 1; true; n++)
+                                {
+                                    if (!ParentDirectory.Items.ContainsKey($"{Sub.Name}_{n}"))
+                                    {
+                                        Sub.Name = $"{Sub.Name}_{n}";
+                                        break;
+                                    }
+                                }
                             }
+                            ParentDirectory.Items.Add(Sub.Name, Sub);
                         }
                     }
                 }

--- a/lib/AuroraLip/Archives/Formats/bres.cs
+++ b/lib/AuroraLip/Archives/Formats/bres.cs
@@ -88,10 +88,18 @@ namespace AuroraLip.Archives.Formats
                             if (Magic != "RASD" && FileSize <= stream.Length - stream.Position)
                             {
                                 Sub.FileData = new ArchiveFile.ArchiveFileStream(stream, FileSize) { Parent = Sub };
-                                if (!ParentDirectory.Items.ContainsKey(Sub.Name))
+                                if (ParentDirectory.Items.ContainsKey(Sub.Name))
                                 {
-                                    ParentDirectory.Items.Add(Sub.Name, Sub);
+                                    for (int n = 1; true; n++)
+                                    {
+                                        if (!ParentDirectory.Items.ContainsKey($"{Sub.Name}_{n}"))
+                                        {
+                                            Sub.Name = $"{Sub.Name}_{n}";
+                                            break;
+                                        }
+                                    }
                                 }
+                                ParentDirectory.Items.Add(Sub.Name, Sub);
                             }
                         }
                         else


### PR DESCRIPTION
BRRES archives with multiple items with the same name would cause an error when being extracted. This fix makes it so items with a key already in the collection will simply be skipped instead.