### PR TITLE
add ArbitraryMipmapDetection

### DIFF
--- a/TextureExtraction tool/Mods.cs
+++ b/TextureExtraction tool/Mods.cs
@@ -37,7 +37,7 @@
         public static ReadOnlySpan<Options> GetOptions(this Modes mode) => mode switch
         {
             Modes.Help => Array.Empty<Options>(),
-            Modes.Extract => new[] { Options.Force, Options.Tasks, Options.Dryrun, Options.Progress, Options.Mip, Options.Raw, Options.Cleanup, Options.Dolphinmipdetection },
+            Modes.Extract => new[] { Options.Force, Options.Tasks, Options.Dryrun, Options.Progress, Options.Mip, Options.Raw, Options.Cleanup, Options.Dolphinmipdetection, Options.ArbitraryMipmapDetection },
             Modes.Unpack => new[] { Options.Force, Options.Tasks, Options.Dryrun, Options.Progress, Options.Recursiv },
             Modes.Compress => new[] { Options.Tasks, Options.Progress },
             Modes.Split => new[] { Options.Tasks, Options.Dryrun, Options.Progress },

--- a/TextureExtraction tool/Options.cs
+++ b/TextureExtraction tool/Options.cs
@@ -12,6 +12,7 @@ namespace DolphinTextureExtraction
         Raw,
         Cleanup,
         Dolphinmipdetection,
+        ArbitraryMipmapDetection,
         Recursiv,
     }
 
@@ -28,6 +29,7 @@ namespace DolphinTextureExtraction
             Options.Cleanup => "Folder cleanup typ.",
             Options.Dolphinmipdetection => "Tries to imitate dolphin mipmap detection.",
             Options.Recursiv => "Extract recursiv.",
+            Options.ArbitraryMipmapDetection => "use Arbitrary Mipmap Detection",
             _ => throw new NotImplementedException(),
         };
 
@@ -42,6 +44,7 @@ namespace DolphinTextureExtraction
             Options.Cleanup => "c",
             Options.Dolphinmipdetection => "dmd",
             Options.Recursiv => "rc",
+            Options.ArbitraryMipmapDetection => "amd",
             _ => throw new NotImplementedException(),
         };
 
@@ -57,6 +60,7 @@ namespace DolphinTextureExtraction
             Options.Cleanup => $"{Options.Cleanup}:Mode",
             Options.Dolphinmipdetection => string.Empty,
             Options.Recursiv => string.Empty,
+            Options.ArbitraryMipmapDetection => string.Empty,
             _ => throw new NotImplementedException(),
         };
 

--- a/TextureExtraction tool/Program.cs
+++ b/TextureExtraction tool/Program.cs
@@ -566,6 +566,9 @@ namespace DolphinTextureExtraction
                     case Options.Recursiv:
                         ConsoleEx.WriteLineBoolPrint(options.Deep == 0, ConsoleColor.Green, ConsoleColor.Red);
                         break;
+                    case Options.ArbitraryMipmapDetection:
+                        ConsoleEx.WriteLineBoolPrint(options.ArbitraryMipmapDetection, ConsoleColor.Green, ConsoleColor.Red);
+                        break;
                     default:
                         throw new NotImplementedException();
                 }
@@ -621,6 +624,10 @@ namespace DolphinTextureExtraction
                     case Options.Recursiv:
                         HelpPrintTrueFalse(options.Deep == 0);
                         options.Deep = ConsoleEx.WriteLineBoolPrint(ConsoleEx.ReadBool(options.Deep == 0, ConsoleKey.T, ConsoleKey.F), "True", "\tFalse", ConsoleColor.Green, ConsoleColor.Red) ? (uint)0 : (uint)1;
+                        break;
+                    case Options.ArbitraryMipmapDetection:
+                        HelpPrintTrueFalse(options.ArbitraryMipmapDetection);
+                        options.ArbitraryMipmapDetection = ConsoleEx.WriteLineBoolPrint(ConsoleEx.ReadBool(options.ArbitraryMipmapDetection, ConsoleKey.T, ConsoleKey.F), "True", "\tFalse", ConsoleColor.Green, ConsoleColor.Red);
                         break;
                     default:
                         throw new NotImplementedException();
@@ -719,6 +726,9 @@ namespace DolphinTextureExtraction
                             break;
                         case Options.Recursiv:
                             options.Deep = 1;
+                            break;
+                        case Options.ArbitraryMipmapDetection:
+                            options.ArbitraryMipmapDetection = true;
                             break;
                         default:
                             throw new NotImplementedException();


### PR DESCRIPTION
fix #24 

The tool can now recognize arbitrary mipmaps. 
when saving mips is turned off arbitrary mipmaps are still saved as long as ArbitraryMipmapDetection is active.