### PR TITLE
Pokémon XD: Add file format 0x11 (& fix GTX I8 format)

### DIFF
--- a/lib/AuroraLip/Archives/Formats/FSYS.cs
+++ b/lib/AuroraLip/Archives/Formats/FSYS.cs
@@ -230,6 +230,8 @@ namespace AuroraLib.Archives.Formats
             /// </summary>
             WZX = 0x10,
 
+            GSFILE11 = 0x11,
+
             /// <summary>
             /// Music file header.
             /// </summary>

--- a/lib/AuroraLip/Common/FormatDictionary_List.cs
+++ b/lib/AuroraLip/Common/FormatDictionary_List.cs
@@ -157,6 +157,7 @@ namespace AuroraLib.Common
             new FormatInfo(".GSscene", FormatType.Texture, "Genius Sonority Scene File (based on sysdolphin)", "Genius Sonority"){ Class = typeof(GSScene) },
             new FormatInfo(".FLOORDAT", FormatType.Texture, "Genius Sonority Floor Model", "Genius Sonority"){ Class = typeof(GSScene) },
             new FormatInfo(".MODELDAT", FormatType.Texture, "Genius Sonority Character Model", "Genius Sonority"){ Class = typeof(GSScene) },
+            new FormatInfo(".GSFILE11", FormatType.Archive, "Genius Sonority Unknown (#0x11)", "Genius Sonority"){ Class = typeof(GSFILE11), IsMatch = GSFILE11.Matcher },
             new FormatInfo(".PKX", FormatType.Archive, "Genius Sonority Pokémons", "Genius Sonority"){ Class = typeof(PKX), IsMatch = PKX.Matcher },
             new FormatInfo(".GSW", FormatType.Archive, "Genius Sonority W?", "Genius Sonority"){ Class = typeof(GSW) },
             new FormatInfo(".GSAGTX", FormatType.Archive, "Genius Sonority Animated Texture", "Genius Sonority"){ Class = typeof(GSAGTX) },

--- a/lib/AuroraLip/Texture/Formats/GSFILE11.cs
+++ b/lib/AuroraLip/Texture/Formats/GSFILE11.cs
@@ -1,0 +1,84 @@
+﻿
+using AuroraLib.Archives;
+using AuroraLib.Common;
+
+namespace AuroraLib.Texture.Formats
+{
+
+    /// <summary>
+    /// Genius Sonority "0x11" file format.
+    /// Real file extension is unknown, number is from FSYS filetype field
+    /// Based on Pokémon XD Gale of Darkness (GXXP01).
+    /// </summary>
+    public class GSFILE11 : Archive, IMagicIdentify, IFileAccess
+    {
+        public bool CanRead => true;
+
+        public bool CanWrite => false;
+
+        public string Magic => "\x7b\x1e\xe3\xf2";
+
+        public GSFILE11() { }
+
+        public GSFILE11(string filename) : base(filename) { }
+
+        public GSFILE11(Stream stream, string filename = null) : base(stream, filename) { }
+
+        public bool IsMatch(Stream stream, in string extension = "")
+            => Matcher(stream, extension);
+
+        public static bool Matcher(Stream stream, in string extension = "")
+            => extension.ToLower() == ".gsfile11"
+                && stream.At(0, s => s.ReadInt32(Endian.Big) == 0x7B1EE3F2);
+
+        protected override void Read(Stream stream)
+        {
+            Root = new ArchiveDirectory() { OwnerArchive = this };
+            Header header = stream.Read<Header>(Endian.Big);
+
+            if (header.Magic != 0x7B1EE3F2)
+            {
+                // TODO: In GXXP01 T1_ancient_colo.fsys/02500200_T1_ancient_colo.GSFILE11 uses 0x7B1EE3F0, maybe check Colosseum code? XD just does nothing if magic doesn't match
+                throw new Exception($"Magic does not match: {header.Magic:X8} (expected 7B1EE3F2)");
+            }
+
+            uint texture_entries_offset = 0x2C + 16u * header.NumEntries;
+
+            for (uint i = 0; i < header.NumTextures; i++)
+            {
+                stream.Seek(texture_entries_offset + 8u * i, SeekOrigin.Begin);
+                TextureEntry tex_entry = stream.Read<TextureEntry>(Endian.Big);
+                Root.AddArchiveFile(stream, stream.Length - tex_entry.TextureOffset,
+                    tex_entry.TextureOffset, $"{tex_entry.TextureOffset:X8}.GTX");
+                // TODO: FIlters are explicitly set to linear (and none for mipmaps), does this matter?
+            }
+        }
+
+        protected override void Write(Stream ArchiveFile)
+        {
+            throw new NotImplementedException();
+        }
+
+        public struct Header
+        {
+            public uint Magic; // 0x7B1EE3F2
+            public ushort NumTextures;
+            public ushort NumEntries;
+            public uint Unknown0C;
+            public uint Unknown10;
+            public uint Unknown14;
+            public uint Unknown18;
+            public uint Unknown1C;
+            public uint Unknown20;
+            public uint Unknown24;
+            public uint Unknown28;
+        }
+
+        public struct TextureEntry
+        {
+            public ushort Index;
+            public ushort Unknown02;
+            public uint TextureOffset;
+        }
+    }
+}

--- a/lib/AuroraLip/Texture/Formats/GTX.cs
+++ b/lib/AuroraLip/Texture/Formats/GTX.cs
@@ -1,4 +1,5 @@
 ﻿using AuroraLib.Common;
+using System.Diagnostics;
 
 namespace AuroraLib.Texture.Formats
 {
@@ -20,7 +21,7 @@ namespace AuroraLib.Texture.Formats
         {
             GTXHeader header = stream.Read<GTXHeader>(Endian.Big);
 
-            GXImageFormat GXFormat = (GXImageFormat)Enum.Parse(typeof(GXImageFormat), header.Format.ToString());
+            GXImageFormat GXFormat = GTX2GXImageFormat(header.Format);
             GXPaletteFormat GXPalette = GXPaletteFormat.IA8;
             byte[] PaletteData = null;
             int PaletteCount = 0;
@@ -64,6 +65,20 @@ namespace AuroraLib.Texture.Formats
         protected override void Write(Stream stream)
         {
             throw new NotImplementedException();
+        }
+
+        protected GXImageFormat GTX2GXImageFormat(GTXFormat format)
+        {
+            switch (format)
+            {
+                case GTXFormat.I8_A0:
+                case GTXFormat.I8_A1:
+                case GTXFormat.I8_A2:
+                case GTXFormat.I8_A3:
+                    return GXImageFormat.I8;
+                default:
+                    return (GXImageFormat)Enum.Parse(typeof(GXImageFormat), format.ToString());
+            }
         }
 
         public struct GTXHeader
@@ -148,7 +163,11 @@ namespace AuroraLib.Texture.Formats
             // which maps GX 0x27-0x2a (all unknown) to GTX 0xa0-0xa3, but not the other way around.
             // But there is also a GTX to something texture format conversion function (GXXP01 @ 0x801030c0)
             // that also maps each to a different value if a passed bool is unset.
-            I8 = 0x42 | 0xa0 | 0xa1 | 0xa2 | 0xa3,
+            I8 = 0x42,
+            I8_A0 = 0xa0,
+            I8_A1 = 0xa1,
+            I8_A2 = 0xa2,
+            I8_A3 = 0xa3,
             IA8 = 0x43,
             RGB565 = 0x44,
             RGBA32 = 0x45,


### PR DESCRIPTION
Dumps 4 more textures in GXXP01 (Pokémon XD Gale of Darkness, PAL).
As the commit message explains, only 2 files uses such format, but just one file gets actually loaded.
So some work is probably still needed for the other file (and/or maybe look into Colosseum if it implements that format). Also since that file doesn't get loaded ingame anyway, we technically doesn't need to dump it.