### PR TITLE
Add Epic Mickey pak file (archive) support

### DIFF
--- a/lib/AuroraLip/Archives/Formats/PAK_JPS.cs
+++ b/lib/AuroraLip/Archives/Formats/PAK_JPS.cs
@@ -1,0 +1,67 @@
+﻿using AuroraLib.Common;
+using AuroraLib.Compression.Formats;
+using AuroraLib.Compression;
+using AuroraLib.Common.Struct;
+
+namespace AuroraLib.Archives.Formats
+{
+    public class PAK_JPS : Archive, IHasIdentifier, IFileAccess
+    {
+        private static readonly Identifier32 _identifier = new(0x20, (byte)'K', (byte)'A', (byte)'P');
+
+        public virtual IIdentifier Identifier => _identifier;
+
+        public bool CanRead => true;
+
+        public bool CanWrite => false;
+
+        public bool IsMatch(Stream stream, in string extension = "")
+            => stream.Match(_identifier);
+
+        protected override void Read(Stream stream)
+        {
+            stream.MatchThrow(_identifier);
+            int version = stream.ReadInt32(Endian.Big);
+            int zero = stream.ReadInt32(Endian.Big);
+            int size = stream.ReadInt32(Endian.Big);
+            int data_pos = stream.ReadInt32(Endian.Big);
+            data_pos += size;
+            stream.Seek(size, SeekOrigin.Begin);
+            int file_count = stream.ReadInt32(Endian.Big);
+            long string_table_position = file_count * 24 + stream.Position;
+            long current_file_data_position = data_pos;
+
+            var zlib = new ZLib();
+            Root = new ArchiveDirectory() { OwnerArchive = this };
+            for (int i = 0; i < file_count; i++)
+            {
+                int uncompressed_size = stream.ReadInt32(Endian.Big);
+                int compressed_size = stream.ReadInt32(Endian.Big);
+                int aligned_size = stream.ReadInt32(Endian.Big);
+                int folder_name_offset = stream.ReadInt32(Endian.Big);
+                string file_type = stream.ReadString(4);
+                int file_name_offset = stream.ReadInt32(Endian.Big);
+
+                long pos = stream.Position;
+                stream.Seek(string_table_position + file_name_offset, SeekOrigin.Begin);
+                string file_name = stream.ReadString();
+
+                if (compressed_size == uncompressed_size)
+                {
+                    Root.AddArchiveFile(stream, uncompressed_size, current_file_data_position, file_name);
+                }
+                else
+                {
+                    stream.Seek(current_file_data_position, SeekOrigin.Begin);
+                    byte[] bytes = stream.Read((int)compressed_size).ToArray();
+                    var decompressed_stream = zlib.Decompress(bytes, 4096, false);
+                    Root.AddArchiveFile(decompressed_stream, file_name);
+                }
+                current_file_data_position += aligned_size;
+                stream.Seek(pos, SeekOrigin.Begin);
+            }
+        }
+
+        protected override void Write(Stream stream) => throw new NotImplementedException();
+    }
+}

--- a/lib/AuroraLip/Common/FormatDictionary_List.cs
+++ b/lib/AuroraLip/Common/FormatDictionary_List.cs
@@ -328,6 +328,9 @@ namespace AuroraLib.Common
             //Capcom
             new FormatInfo("", FormatType.Archive, "MT Framework Archive", "Capcom"){ Class = typeof(ARC_MTF)},
 
+            //Disney
+            new FormatInfo("", FormatType.Archive, "Junction Point Studios Archive", "Junction Point Studios"){ Class = typeof(PAK_JPS)},
+
             //UbiSoft
             new FormatInfo(".bf",new Identifier32((byte)'B',(byte)'U',(byte)'G',0), FormatType.Archive, "UbiSoft Archive","UbiSoft"),
             new FormatInfo(".bf", new Identifier32((byte)'B',(byte)'I',(byte)'G',0), FormatType.Archive, "UbiSoft Archive","UbiSoft",typeof(BIG)),


### PR DESCRIPTION
Unfortunately, the texture inside seems to be a Gamebryo file.  Specifically for Epic Mickey, the data has never been cracked.  The gamebryo tool seems to treat as a DDS file.  We don't have DDS support but not sure that's correct.

See: https://github.com/niftools/nifskope/issues/172
See the users' work around:  https://www.youtube.com/watch?v=08RoSv0Uczo