### PR TITLE
Find more Rune Factory Tides of Destiny Textures

### DIFF
--- a/lib/AuroraLip/Archives/Formats/MEDB.cs
+++ b/lib/AuroraLip/Archives/Formats/MEDB.cs
@@ -1,0 +1,65 @@
+﻿using AuroraLib.Common;
+using AuroraLib.Common.Struct;
+
+namespace AuroraLib.Archives.Formats
+{
+    // Rune Factory (Tides) archive format
+    public class MEDB : Archive, IHasIdentifier, IFileAccess
+    {
+        public bool CanRead => true;
+
+        public bool CanWrite => false;
+
+        public virtual IIdentifier Identifier => _identifier;
+
+        private static readonly Identifier32 _identifier = new("MEDB");
+
+        public MEDB()
+        { }
+
+        public MEDB(string filename) : base(filename)
+        {
+        }
+
+        public MEDB(Stream stream, string filename = null) : base(stream, filename)
+        {
+        }
+
+        public bool IsMatch(Stream stream, in string extension = "")
+            => stream.Match(_identifier);
+
+        protected override void Read(Stream stream)
+        {
+            stream.MatchThrow(_identifier);
+
+            Root = new ArchiveDirectory() { OwnerArchive = this };
+
+            // We know there are textures here, just search for them
+            while (stream.Search("HXTB"))
+            {
+                long entrystart = stream.Position;
+                if (!stream.Match("HXTB"))
+                    continue;
+                stream.Seek(0x14, SeekOrigin.Current);
+                uint total_size = stream.ReadUInt32(Endian.Big);
+
+                if (total_size > stream.Length - entrystart)
+                {
+                    stream.Search("HXTB");
+                    total_size = (uint)(stream.Position - entrystart);
+                }
+
+                ArchiveFile Sub = new ArchiveFile() { Parent = Root, Name = $"entry_{TotalFileCount + 1}.hxtb" };
+                Sub.FileData = new SubStream(stream, total_size, entrystart);
+                Root.Items.Add(Sub.Name, Sub);
+
+                stream.Position = entrystart + total_size;
+            }
+        }
+
+        protected override void Write(Stream ArchiveFile)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/lib/AuroraLip/Archives/Formats/NLCL.cs
+++ b/lib/AuroraLip/Archives/Formats/NLCL.cs
@@ -1,0 +1,67 @@
+﻿using AuroraLib.Common;
+using AuroraLib.Common.Struct;
+
+namespace AuroraLib.Archives.Formats
+{
+    // Rune Factory (Tides) archive format
+    public class NLCL : Archive, IHasIdentifier, IFileAccess
+    {
+        public bool CanRead => true;
+
+        public bool CanWrite => false;
+
+        public virtual IIdentifier Identifier => _identifier;
+
+        private static readonly Identifier32 _identifier = new("NLCL");
+
+        public NLCL()
+        { }
+
+        public NLCL(string filename) : base(filename)
+        {
+        }
+
+        public NLCL(Stream stream, string filename = null) : base(stream, filename)
+        {
+        }
+
+        public bool IsMatch(Stream stream, in string extension = "")
+            => stream.Match(_identifier);
+
+        protected override void Read(Stream stream)
+        {
+            stream.MatchThrow(_identifier);
+
+            Root = new ArchiveDirectory() { OwnerArchive = this };
+
+            // This archive can have other things in it.  But it
+            // isn't clear to me how the each file is sourced
+            // there is a count but no offset...
+            while (stream.Search("HXTB"))
+            {
+                long entrystart = stream.Position;
+                if (!stream.Match("HXTB"))
+                    continue;
+                stream.Seek(0x14, SeekOrigin.Current);
+                uint total_size = stream.ReadUInt32(Endian.Big);
+
+                if (total_size > stream.Length - entrystart)
+                {
+                    stream.Search("HXTB");
+                    total_size = (uint)(stream.Position - entrystart);
+                }
+
+                ArchiveFile Sub = new ArchiveFile() { Parent = Root, Name = $"entry_{TotalFileCount + 1}.hxtb" };
+                Sub.FileData = new SubStream(stream, total_size, entrystart);
+                Root.Items.Add(Sub.Name, Sub);
+
+                stream.Position = entrystart + total_size;
+            }
+        }
+
+        protected override void Write(Stream ArchiveFile)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/lib/AuroraLip/Common/FormatDictionary_List.cs
+++ b/lib/AuroraLip/Common/FormatDictionary_List.cs
@@ -376,6 +376,8 @@ namespace AuroraLib.Common
             //Neverland
             new FormatInfo(".bin", "FBTI", FormatType.Archive, "Rune Factory Archive", "Neverland",typeof(FBTI)),
             new FormatInfo(".bin", "NLCM", FormatType.Archive, "Rune Factory Archive Header", "Neverland",typeof(NLCM)),
+            new FormatInfo("", "NLCL", FormatType.Archive, "Rune Factory Archive 2", "Neverland",typeof(NLCL)),
+            new FormatInfo("", "MEDB", FormatType.Archive, "Rune Factory Archive 3", "Neverland",typeof(MEDB)),
             new FormatInfo(".hvt", "HXTB", FormatType.Texture, "Rune Factory Texture", "Neverland",typeof(HXTB)),
 
             //Square Enix


### PR DESCRIPTION
Unlike my original investigation, I didn't fully reverse these.  I started on NLCL and had some issues deducing how to find each entry's offset.  I finally decided to just look for the textures themselves.  After only finding a handful of textures, I looked for other references and noticed the MEDB files had textures as well.  I did not look at these files in any detail, so they might not be an archive in the strict sense.  In the future, maybe I'll look at these formats in more detail.

For now this gives ToD another 1000+ textures or so.