### PR TITLE
Support RVZ format

### DIFF
--- a/TextureExtraction tool/Program.cs
+++ b/TextureExtraction tool/Program.cs
@@ -530,11 +530,7 @@ namespace DolphinTextureExtraction
             Console.WriteLine($"Supported formats: {string.Join(", ", formats)}.".LineBreak(20));
 
             ConsoleEx.WriteLineColoured(StringEx.Divider(), ConsoleColor.Blue);
-            ConsoleEx.WriteColoured("INFO:", ConsoleColor.Red);
-            Console.WriteLine(" If you use RVZ images, unpack them into a folder using Dolphin.");
-            Console.WriteLine("right click on a game -> Properties -> Filesystem -> right click on \"Disc - [Game ID]\" -> Extract Files...");
             Console.ResetColor();
-            Console.WriteLine();
         }
 
         static void PrintOptions()

--- a/lib/AuroraLip/Archives/Formats/RVZ.cs
+++ b/lib/AuroraLip/Archives/Formats/RVZ.cs
@@ -1,0 +1,62 @@
+﻿using AuroraLib.Common;
+using AuroraLib.Core.Interfaces;
+using AuroraLib.DiscImage.Dolphin;
+using AuroraLib.DiscImage.Revolution;
+using AuroraLib.DiscImage.RVZ;
+
+namespace AuroraLib.Archives.Formats
+{
+    public partial class RVZ : Archive, IHasIdentifier, IFileAccess
+    {
+        public bool CanRead => true;
+
+        public bool CanWrite => false;
+
+        public virtual IIdentifier Identifier => _identifier;
+
+        private static readonly Identifier32 _identifier = new(82, 86, 90, 1);
+
+        private RvzStream rvzStream;
+
+        public GameHeader Header;
+
+        public bool IsMatch(Stream stream, ReadOnlySpan<char> extension = default)
+            => stream.Match(_identifier);
+
+        protected override void Read(Stream stream)
+        {
+            rvzStream = new(stream);
+            GCDisk reader;
+            if (rvzStream.RVZDiscT.DiscType == DiscTypes.GameCube)
+            {
+                reader = new GCDisk();
+                reader.Open(rvzStream);
+            }
+            else
+            {
+                HeaderBin wiiHeader = new(rvzStream)
+                {
+                    UseVerification = false,
+                    UseEncryption = false
+                };
+                reader = new WiiDisk { Header = wiiHeader };
+                ((WiiDisk)reader).ProcessPartitionData(rvzStream);
+            }
+
+            Root = reader.Root;
+            reader.Root = null;
+            Header = reader.Header;
+        }
+
+        protected override void Write(Stream stream) => throw new NotImplementedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+            {
+                rvzStream?.Dispose();
+            }
+        }
+    }
+}

--- a/lib/AuroraLip/Common/FormatDictionary_List.cs
+++ b/lib/AuroraLip/Common/FormatDictionary_List.cs
@@ -2,6 +2,7 @@
 using AuroraLib.Compression.Algorithms;
 using AuroraLib.Compression.Formats;
 using AuroraLib.Core.Text;
+using AuroraLib.DiscImage.RVZ;
 using AuroraLib.Texture;
 using AuroraLib.Texture.Formats;
 
@@ -316,7 +317,7 @@ namespace AuroraLib.Common
             //Roms & Iso
             new FormatInfo(".gba", 0,new byte[]{46,0,0,234,36,255,174,81,105,154,162,33,61,132,130}, FormatType.Rom, "GBA Rom", Nin_),
             new FormatInfo(".nes", 0,new byte[]{78,69,83,26} , FormatType.Rom, "Rom", Nin_),
-            new FormatInfo(".rvz", 0,new byte[]{82,86,90,1} , FormatType.Iso, "Dolphin Iso", "Dolphin Team"),
+            new FormatInfo(".rvz", 0,new byte[]{82,86,90,1} , FormatType.Iso, "Dolphin Iso", "Dolphin Team",typeof(RVZ)),
             new FormatInfo(".WIA", 0,new byte[]{87,73,65,1} , FormatType.Iso, "Wii ISO Archive","Wiimm"),
             new FormatInfo(".wad",new Identifier32((byte)'I', (byte)'s', 0, 0),4, FormatType.Iso, "Wii WAD",Nin_,typeof(WAD)),
             new FormatInfo(".ciso", FormatType.Iso, "Compact ISO"),

--- a/lib/AuroraLip/DiscImage/RVZ/CompressionTypes.cs
+++ b/lib/AuroraLip/DiscImage/RVZ/CompressionTypes.cs
@@ -1,0 +1,12 @@
+﻿namespace AuroraLib.DiscImage.RVZ
+{
+    public enum CompressionTypes : uint
+    {
+        None = 0,
+        PURGE = 1,
+        BZIP2 = 2,
+        LZMA = 3,
+        LZMA2 = 4,
+        Zstandard = 5,
+    }
+}

--- a/lib/AuroraLip/DiscImage/RVZ/DiscT.cs
+++ b/lib/AuroraLip/DiscImage/RVZ/DiscT.cs
@@ -1,0 +1,121 @@
+﻿using AuroraLib.Compression;
+using AuroraLib.Compression.Formats;
+using AuroraLib.Compression.Interfaces;
+using AuroraLib.Core.Interfaces;
+using System.Buffers;
+using System.Runtime.InteropServices;
+
+namespace AuroraLib.DiscImage.RVZ
+{
+    public class DiscT : IBinaryObject
+    {
+        public DiscTypes DiscType;
+        public CompressionTypes Compression;
+        public int CompressionLevel;
+        public uint ChunkSize;
+        // The first 0x80 bytes of the disc image.
+        public readonly byte[] DiscHead;
+        public PartT[] Parts;
+        public readonly byte[] PartsHash;
+        public RawDataT[] RawData;
+        public RvzGroupT[] Groups;
+        public byte[] AlgorithmData;
+
+        public DiscT()
+        {
+            PartsHash = new byte[0x14];
+            DiscHead = new byte[0x80];
+        }
+
+        public DiscT(Stream source) : this() => BinaryDeserialize(source);
+
+        public ICompressionDecoder GetDecoder() => Compression switch
+        {
+            CompressionTypes.Zstandard => new Zstd(),
+            _ => throw new NotImplementedException($"{Compression} compression is currently not supported."),
+        };
+        public ICompressionEncoder GetEncoder() => Compression switch
+        {
+            CompressionTypes.Zstandard => new Zstd(),
+            _ => throw new NotImplementedException(),
+        };
+
+
+        public void BinaryDeserialize(Stream source)
+        {
+            source.Seek(0x48, SeekOrigin.Begin);
+            DiscType = source.Read<DiscTypes>(Endian.Big);
+            Compression = source.Read<CompressionTypes>(Endian.Big);
+            CompressionLevel = source.Read<int>(Endian.Big);
+            ChunkSize = source.Read<uint>(Endian.Big);
+            source.Read(DiscHead); // The first 0x80 bytes of the disc image.
+            uint partsLength = source.Read<uint>(Endian.Big); // The number of wia_part_t structs.
+            uint partSize = source.Read<uint>(Endian.Big);
+            long partsOffset = source.Read<long>(Endian.Big);
+            source.Read(PartsHash);
+            uint rawDataStruct = source.Read<uint>(Endian.Big);
+            long rawOffset = source.Read<long>(Endian.Big);
+            uint rawComSize = source.Read<uint>(Endian.Big);
+            uint groups = source.Read<uint>(Endian.Big);
+            long groupsOffset = source.Read<long>(Endian.Big);
+            uint groupsComSize = source.Read<uint>(Endian.Big);
+            uint algorithmDataSize = source.Read<uint>(Endian.Big);
+            AlgorithmData = source.Read(algorithmDataSize);
+
+            long endPose = source.Position;
+            ICompressionDecoder decoder = GetDecoder();
+
+            //read Partd data
+            source.Seek(partsOffset, SeekOrigin.Begin);
+            Parts = new PartT[partsLength];
+            if (partSize == 0x30)
+            {
+                for (int i = 0; i < partsLength; i++)
+                    Parts[i] = source.Read<PartT>();
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+
+            using MemoryPoolStream rawData = decoder.Decompress(new SubStream(source, rawComSize, rawOffset));
+            RawData = rawData.Read<RawDataT>(rawDataStruct, Endian.Big);
+            // The first wia_raw_data_t has raw_data_off set to 0x80 and raw_data_size set to 0x4FF80, but it actually contains 0x50000 bytes of data!
+            RawData[0] = new(0, RawData[0].DataSize + 0x80, 0, RawData[0].Groups);
+
+            using MemoryPoolStream groupData = decoder.Decompress(new SubStream(source, groupsComSize, groupsOffset));
+            Groups = groupData.Read<RvzGroupT>(groups, Endian.Big);
+
+        }
+
+        public void BinarySerialize(Stream dest)
+        {
+            RawData[0] = new(0x80, RawData[0].DataSize - 0x80, 0, RawData[0].Groups);
+            ICompressionEncoder encoder = GetEncoder();
+            dest.Write(DiscType, Endian.Big);
+            dest.Write(Compression, Endian.Big);
+            dest.Write(CompressionLevel, Endian.Big);
+            dest.Write(ChunkSize, Endian.Big);
+            dest.Write(DiscHead);
+            dest.Write(Parts.Length, Endian.Big);
+            dest.Write(0x30, Endian.Big);
+            dest.Write<long>(292 + AlgorithmData.Length, Endian.Big);
+            dest.Write(PartsHash);
+            Span<byte> rawDataBytes = MemoryMarshal.Cast<RawDataT, byte>(RawData);
+            using MemoryPoolStream databuffer = encoder.Compress(rawDataBytes);
+            dest.Write(RawData.Length, Endian.Big);
+            dest.Write<long>(292 + AlgorithmData.Length + (Parts.Length * 0x30), Endian.Big);
+            dest.Write((uint)databuffer.Length, Endian.Big);
+            Span<byte> groupBytes = MemoryMarshal.Cast<RvzGroupT, byte>(Groups);
+            using MemoryPoolStream groupCom = encoder.Compress(groupBytes);
+            dest.Write(Groups.Length, Endian.Big);
+            dest.Write<long>(292 + AlgorithmData.Length + (Parts.Length * 0x30) + databuffer.Length, Endian.Big);
+            dest.Write((uint)groupCom.Length, Endian.Big);
+            dest.Write(AlgorithmData.Length, Endian.Big);
+            dest.Write(AlgorithmData);
+            databuffer.WriteTo(dest);
+            groupCom.WriteTo(dest);
+            RawData[0] = new(0, RawData[0].DataSize + 0x80, 0, RawData[0].Groups);
+        }
+    }
+}

--- a/lib/AuroraLip/DiscImage/RVZ/DiscTypes.cs
+++ b/lib/AuroraLip/DiscImage/RVZ/DiscTypes.cs
@@ -1,0 +1,8 @@
+﻿namespace AuroraLib.DiscImage.RVZ
+{
+    public enum DiscTypes : uint
+    {
+        GameCube = 1,
+        Wii = 2,
+    }
+}

--- a/lib/AuroraLip/DiscImage/RVZ/ExceptListT.cs
+++ b/lib/AuroraLip/DiscImage/RVZ/ExceptListT.cs
@@ -1,0 +1,9 @@
+﻿namespace AuroraLib.DiscImage.RVZ
+{
+    public readonly struct ExceptListT
+    {
+        public readonly ushort Offset;
+        public readonly UInt128 Hash;
+
+    }
+}

--- a/lib/AuroraLip/DiscImage/RVZ/ExceptionT.cs
+++ b/lib/AuroraLip/DiscImage/RVZ/ExceptionT.cs
@@ -1,0 +1,25 @@
+﻿using AuroraLib.Core.Interfaces;
+
+namespace AuroraLib.DiscImage.RVZ
+{
+    public class ExceptionT : IBinaryObject
+    {
+        public ushort Offset;
+        public readonly byte[] Hash;
+
+        public ExceptionT()
+            => Hash = new byte[20];
+
+        public void BinaryDeserialize(Stream source)
+        {
+            Offset = source.ReadUInt16(Endian.Big);
+            source.Read(Hash);
+        }
+
+        public void BinarySerialize(Stream dest)
+        {
+            dest.Write(Offset);
+            dest.Write(Hash);
+        }
+    }
+}

--- a/lib/AuroraLip/DiscImage/RVZ/Header.cs
+++ b/lib/AuroraLip/DiscImage/RVZ/Header.cs
@@ -1,0 +1,49 @@
+﻿using AuroraLib.Core.Interfaces;
+using System.Buffers;
+
+namespace AuroraLib.DiscImage.RVZ
+{
+    public class Header : IBinaryObject
+    {
+        public ImageType Magic;
+        public RvzVersion Version;
+        public RvzVersion VersionCompatible;
+        public uint DiscTSize;
+        public readonly byte[] DiscHash;
+        public long IsoFileSize;
+        public long ThisFileSize;
+        public readonly byte[] HeaderHash;
+
+        public Header()
+        {
+            DiscHash = new byte[0x14];
+            HeaderHash = new byte[0x14];
+        }
+
+        public Header(Stream source) : this() => BinaryDeserialize(source);
+
+        public void BinaryDeserialize(Stream source)
+        {
+            Magic = source.Read<ImageType>(Endian.Big);
+            Version = source.Read<RvzVersion>(Endian.Big);
+            VersionCompatible = source.Read<RvzVersion>(Endian.Big);
+            DiscTSize = source.Read<uint>(Endian.Big);
+            source.Read(DiscHash);
+            IsoFileSize = source.Read<long>(Endian.Big);
+            ThisFileSize = source.Read<long>(Endian.Big);
+            source.Read(HeaderHash);
+        }
+
+        public void BinarySerialize(Stream dest)
+        {
+            dest.Write(Magic);
+            dest.Write(Version);
+            dest.Write(VersionCompatible);
+            dest.Write(DiscTSize);
+            dest.Write(DiscHash);
+            dest.Write(IsoFileSize);
+            dest.Write(ThisFileSize);
+            dest.Write(HeaderHash);
+        }
+    }
+}

--- a/lib/AuroraLip/DiscImage/RVZ/ImageType.cs
+++ b/lib/AuroraLip/DiscImage/RVZ/ImageType.cs
@@ -1,0 +1,8 @@
+﻿namespace AuroraLib.DiscImage.RVZ
+{
+    public enum ImageType : uint
+    {
+        WIA = 1464418561,
+        RVZ = 1381390849,
+    }
+}

--- a/lib/AuroraLip/DiscImage/RVZ/LaggedFibonacciGenerator.cs
+++ b/lib/AuroraLip/DiscImage/RVZ/LaggedFibonacciGenerator.cs
@@ -1,0 +1,119 @@
+﻿using AuroraLib.Core.Buffers;
+using System.Runtime.InteropServices;
+
+namespace AuroraLib.DiscImage.RVZ
+{
+    //https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/DiscIO/LaggedFibonacciGenerator.cpp
+    public class LaggedFibonacciGenerator : Stream
+    {
+        private const int LFI = 521;
+        private const int LFIx4 = LFI * 4;
+
+        private readonly SpanBuffer<uint> buffer;
+        public override long Position
+        {
+            get => position;
+            set
+            {
+                if (value < 0)
+                {
+                    Backward();
+                }
+                else if (value >= LFIx4)
+                {
+                    for (int i = 0; i < value / LFIx4; i++)
+                    {
+                        Forward();
+                    }
+                    position = (int)value % LFIx4;
+                }
+                else
+                {
+                    position = (int)value;
+                }
+            }
+        }
+        private int position;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => long.MaxValue;
+
+        public LaggedFibonacciGenerator() => buffer = new SpanBuffer<uint>(LFI);
+
+        public void Initialize(Stream stream)
+        {
+            stream.Read(buffer.Slice(0, 17), Endian.Big);
+            for (int i = 17; i < LFI; i++)
+            {
+                buffer[i] = (buffer[i - 17] << 23) ^ (buffer[i - 16] >> 9) ^ buffer[i - 1];
+            }
+            // Instead of doing the "shift by 18 instead of 16" oddity when actually outputting the data,
+            // we can do the shifting (and byteswapping) at this point to make the read code simpler.
+            for (int i = 0; i < LFI; i++)
+            {
+                buffer[i] = BitConverterX.Swap((buffer[i] & 0xFF00FFFF) | ((buffer[i] >> 2) & 0x00FF0000));
+            }
+
+            Position = 0;
+            for (int i = 0; i < 4; i++)
+                Forward();
+        }
+
+        private void Forward()
+        {
+            for (int i = 0; i < 32; i++)
+                buffer[i] ^= buffer[i + LFI - 32];
+
+            for (int i = 32; i < LFI; i++)
+                buffer[i] ^= buffer[i - 32];
+        }
+
+        private void Backward()
+            => throw new NotImplementedException("LaggedFibonacciGenerator.Backward");
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> outbuffer)
+        {
+            int outPosition = 0;
+            Span<byte> byteBuffer = MemoryMarshal.Cast<uint, byte>(buffer);
+            while (outPosition < outbuffer.Length)
+            {
+                int CopyCount = Math.Min(outbuffer.Length - outPosition, LFIx4 - position);
+                byteBuffer.Slice(position, CopyCount).CopyTo(outbuffer[outPosition..]);
+                Position += CopyCount;
+                outPosition += CopyCount;
+            }
+            return outbuffer.Length;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => origin switch
+        {
+            SeekOrigin.Begin => Position = offset,
+            SeekOrigin.Current => Position += offset,
+            SeekOrigin.End => Position = Length + offset,
+            _ => throw new NotImplementedException(),
+        };
+
+        public override void SetLength(long value) { }
+        public override void Flush() => throw new NotImplementedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+
+        private bool disposedValue;
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    buffer.Dispose();
+                }
+                disposedValue = true;
+            }
+        }
+    }
+}

--- a/lib/AuroraLip/DiscImage/RVZ/PartDataT.cs
+++ b/lib/AuroraLip/DiscImage/RVZ/PartDataT.cs
@@ -1,0 +1,18 @@
+﻿namespace AuroraLib.DiscImage.RVZ
+{
+    public readonly struct PartDataT
+    {
+        public readonly uint FirstSector;
+        public readonly uint Sectors;
+        public readonly uint GroupIndex;
+        public readonly uint Groups;
+
+        public PartDataT(uint firstSector, uint sectors, uint groupIndex, uint groups)
+        {
+            FirstSector = firstSector;
+            Sectors = sectors;
+            GroupIndex = groupIndex;
+            Groups = groups;
+        }
+    }
+}

--- a/lib/AuroraLip/DiscImage/RVZ/PartT.cs
+++ b/lib/AuroraLip/DiscImage/RVZ/PartT.cs
@@ -1,0 +1,28 @@
+﻿using AuroraLib.Core.Interfaces;
+
+namespace AuroraLib.DiscImage.RVZ
+{
+    public class PartT : IBinaryObject
+    {
+        public readonly byte[] PartKey;
+        public PartDataT[] PartData;
+
+        public PartT()
+        {
+            PartKey = new byte[0x10];
+            PartData = new PartDataT[2];
+        }
+
+        public void BinaryDeserialize(Stream source)
+        {
+            source.Read(PartKey);
+            source.Read<PartDataT>(PartData, Endian.Big);
+        }
+
+        public void BinarySerialize(Stream dest)
+        {
+            dest.Write(PartKey);
+            dest.Write<PartDataT>(PartData, Endian.Big);
+        }
+    }
+}

--- a/lib/AuroraLip/DiscImage/RVZ/RVZStream.cs
+++ b/lib/AuroraLip/DiscImage/RVZ/RVZStream.cs
@@ -1,0 +1,213 @@
+﻿using AuroraLib.Compression;
+using AuroraLib.Compression.Interfaces;
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace AuroraLib.DiscImage.RVZ
+{
+    // ToDo, if we want to re-encode the data, we have to recalculate H0, H1 and H2.
+    /// <summary>
+    /// Represents a stream for reading RVZ files.
+    /// </summary>
+    public class RvzStream : Stream
+    {
+        private const int WiiChunkSize = 0x8000;
+        private const int WiiDataSize = 0x7C00;
+
+        private readonly byte[] ChunkBuffer;
+        public readonly Header RVZHeader;
+        public readonly DiscT RVZDiscT;
+        private readonly Stream RVZFileStream;
+        private readonly ICompressionDecoder Decoder;
+        private readonly LaggedFibonacciGenerator PRNG;
+        private int CurrentChunkIndex;
+        private bool IsGroupWii;
+        private RawDataT CurrentGroupList;
+
+        // Stream overrides
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => RVZHeader.IsoFileSize;
+        public override long Position { get; set; }
+
+        public RvzStream(Stream rvzFileStream)
+        {
+            RVZHeader = rvzFileStream.Read<Header>();
+            RVZDiscT = rvzFileStream.Read<DiscT>();
+
+            if (RVZHeader.VersionCompatible.CompareTo(new(1)) > 0)
+            {
+                throw new NotImplementedException($"RVZ {RVZHeader.VersionCompatible} not supported");
+            }
+
+            ChunkBuffer = ArrayPool<byte>.Shared.Rent((int)RVZDiscT.ChunkSize);
+            RVZFileStream = rvzFileStream;
+            Decoder = RVZDiscT.GetDecoder();
+            PRNG = new();
+            Position = 0;
+            CurrentGroupList = RVZDiscT.RawData[0];
+            CurrentChunkIndex = -1;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> buffer)
+        {
+            if (Position >= Length)
+                return 0;
+
+            // Check if we need a new GroupList.
+            if (Position < CurrentGroupList.DataOffset || Position >= CurrentGroupList.DataEndOffset)
+                GetCurrentGroupList();
+
+            // When we read decoded wii data, the chunks have less data because the hashes are missing.
+            uint chunkSize = IsGroupWii ? RVZDiscT.ChunkSize / WiiChunkSize * WiiDataSize : RVZDiscT.ChunkSize;
+            int chunk = (int)(CurrentGroupList.GroupIndex + (Position - CurrentGroupList.DataOffset) / chunkSize);
+            if (chunk != CurrentChunkIndex)
+            {
+                CurrentChunkIndex = chunk;
+                DecodeCurrentChunk();
+            }
+
+            int chunkOffset = (int)((Position - CurrentGroupList.DataOffset) % chunkSize);
+            int CopyCount = (int)Math.Min(buffer.Length, Length - Position);
+            CopyCount = Math.Min((int)Math.Min(chunkSize - chunkOffset, CurrentGroupList.DataSize - (Position - CurrentGroupList.DataOffset)), CopyCount);
+            ChunkBuffer.AsSpan(chunkOffset, CopyCount).CopyTo(buffer);
+            Position += CopyCount;
+
+            // If the read data is in more than one chunk.
+            if (buffer.Length > CopyCount)
+                return Read(buffer[CopyCount..]) + CopyCount;
+            else
+                return CopyCount;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private void GetCurrentGroupList()
+        {
+            for (int i = 0; i < RVZDiscT.RawData.Length; i++)
+            {
+                RawDataT dataT = RVZDiscT.RawData[i];
+
+                if (Position >= dataT.DataOffset && Position < dataT.DataOffset + dataT.DataSize)
+                {
+                    IsGroupWii = false;
+                    CurrentGroupList = dataT;
+                    return;
+                }
+            }
+
+            // Read Wii partition data.
+            for (int i = 0; i < RVZDiscT.Parts.Length; i++)
+            {
+                uint startSector = RVZDiscT.Parts[i].PartData[0].FirstSector;
+                long partitionOffset = (long)startSector * WiiChunkSize;
+                for (int p = 0; p < 2; p++)
+                {
+                    // We read Wii disc partition decoded, which is why we have to adjust the offsets and size.
+                    PartDataT partT = RVZDiscT.Parts[i].PartData[p];
+                    long offset = partitionOffset + ((long)partT.FirstSector - startSector) * WiiDataSize;
+                    long size = (long)partT.Sectors * WiiDataSize;
+                    RawDataT dataT = new(offset, size, partT.GroupIndex, partT.Groups);
+
+                    if (Position < offset + size)
+                    {
+                        IsGroupWii = true;
+                        CurrentGroupList = dataT;
+                        return;
+                    }
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private void DecodeCurrentChunk()
+        {
+            RvzGroupT groupT = RVZDiscT.Groups[CurrentChunkIndex];
+
+            // special case where all bytes are zero.
+            if (groupT.DataSize == 0)
+            {
+                Array.Clear(ChunkBuffer);
+                return;
+            }
+
+            Stream rvzChunk = new SubStream(RVZFileStream, groupT.DataSize, groupT.DataOffset);
+            if (groupT.IsCompressed)
+            {
+                rvzChunk = Decoder.Decompress(rvzChunk);
+            }
+
+            if (IsGroupWii)
+            {
+                // ToDo, find out why 2 bytes have to be read here.
+                if (!groupT.IsCompressed)
+                    _ = rvzChunk.Read<ushort>();
+
+                // These are exceptions that are required when re-encoding Wii discs, we don't need them at the moment.
+                ushort exceptions = rvzChunk.Read<ushort>(Endian.Big);
+                List<ExceptionT> exceptionsList = new(exceptions);
+                for (int i = 0; i < exceptions; i++)
+                {
+                    exceptionsList.Add(rvzChunk.Read<ExceptionT>());
+                }
+            }
+
+            // Is RVZ packaging used?
+            if (groupT.PackedSize == 0)
+            {
+                rvzChunk.Read(ChunkBuffer);
+            }
+            else
+            {
+                int bufferPosition = 0, size;
+                while (rvzChunk.Position < rvzChunk.Length)
+                {
+                    size = rvzChunk.ReadInt32(Endian.Big);
+                    Span<byte> bufferSpan = ChunkBuffer.AsSpan(bufferPosition, size & 0x7FFFFFFF);
+
+                    // Is the PRNG algorithm used?
+                    if ((size & 0x80000000) != 0)
+                    {
+                        PRNG.Initialize(rvzChunk);
+                        PRNG.Position += bufferPosition % WiiChunkSize;
+                        PRNG.Read(bufferSpan);
+                    }
+                    else
+                    {
+                        rvzChunk.Read(bufferSpan);
+                    }
+                    bufferPosition += bufferSpan.Length;
+                }
+            }
+            rvzChunk.Close();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => origin switch
+        {
+            SeekOrigin.Begin => Position = offset,
+            SeekOrigin.Current => Position += offset,
+            SeekOrigin.End => Position = Length + offset,
+            _ => throw new NotImplementedException(),
+        };
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override void Flush() { }
+
+        [DebuggerStepThrough]
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+            {
+                ArrayPool<byte>.Shared.Return(ChunkBuffer);
+
+                PRNG.Dispose();
+            }
+        }
+    }
+}

--- a/lib/AuroraLip/DiscImage/RVZ/RVZVersion.cs
+++ b/lib/AuroraLip/DiscImage/RVZ/RVZVersion.cs
@@ -1,0 +1,41 @@
+﻿namespace AuroraLib.DiscImage.RVZ
+{
+    public readonly struct RvzVersion : IComparable<RvzVersion>
+    {
+        public readonly byte Major;
+        public readonly byte Minor;
+        public readonly byte Build;
+        private readonly byte beta;
+
+        public RvzVersion(byte major, byte minor = 0, byte build = 0, byte beta = 0)
+        {
+            Major = major;
+            Minor = minor;
+            Build = build;
+            this.beta = beta;
+        }
+
+        public readonly bool IsBeta => beta != 0x00 && beta != 0xff;
+
+        public override string ToString()
+        {
+            string versionString = Build == 0 ? $"{Major}.{Minor}" : $"{Major}.{Minor}.{Build}";
+            if (IsBeta)
+            {
+                versionString += $" beta {beta}";
+            }
+            return versionString;
+        }
+
+        public unsafe int CompareTo(RvzVersion other)
+        {
+            if (Major != other.Major)
+                return Major.CompareTo(other.Major);
+            if (Minor != other.Minor)
+                return Minor.CompareTo(other.Minor);
+            if (Build != other.Build)
+                return Build.CompareTo(other.Build);
+            return beta.CompareTo(other.beta);
+        }
+    }
+}

--- a/lib/AuroraLip/DiscImage/RVZ/RawDataT.cs
+++ b/lib/AuroraLip/DiscImage/RVZ/RawDataT.cs
@@ -1,0 +1,20 @@
+﻿namespace AuroraLib.DiscImage.RVZ
+{
+    public readonly struct RawDataT
+    {
+        public readonly long DataOffset;
+        public readonly long DataSize;
+        public readonly uint GroupIndex;
+        public readonly uint Groups;
+
+        public readonly long DataEndOffset => DataOffset + DataSize;
+
+        public RawDataT(long dataOffset, long dataSize, uint groupIndex, uint groups)
+        {
+            DataOffset = dataOffset;
+            DataSize = dataSize;
+            GroupIndex = groupIndex;
+            Groups = groups;
+        }
+    }
+}

--- a/lib/AuroraLip/DiscImage/RVZ/RvzGroupT.cs
+++ b/lib/AuroraLip/DiscImage/RVZ/RvzGroupT.cs
@@ -1,0 +1,13 @@
+﻿namespace AuroraLib.DiscImage.RVZ
+{
+    public readonly struct RvzGroupT
+    {
+        private readonly uint dataOffset;
+        private readonly uint packtDataSize;
+        public readonly uint PackedSize;
+
+        public readonly uint DataOffset => dataOffset << 2;
+        public readonly uint DataSize => packtDataSize & 0x7FFFFFFF;
+        public readonly bool IsCompressed => (packtDataSize & 0x80000000) != 0;
+    }
+}


### PR DESCRIPTION
Reading support for RVZ files with Zstandard compression, other compressions are currently not supported, can easily be added.

The RVZStream class does not currently support re-encoding Wii pation data.

