### PR TITLE
Update packages - ImageSharp vulnerability

### DIFF
--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/lib/AuroraLip/AuroraLib.csproj
+++ b/lib/AuroraLip/AuroraLib.csproj
@@ -27,8 +27,8 @@
     <PackageReference Include="AuroraLib.Compression" Version="1.0.6" />
     <PackageReference Include="RenderWareNET" Version="0.6.1" />
     <PackageReference Include="SevenZipExtractor" Version="1.0.17" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.2" />
-    <PackageReference Include="ZstdSharp.Port" Version="0.7.5" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+    <PackageReference Include="ZstdSharp.Port" Version="0.7.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/lib/Hack.io/Hack.io.csproj
+++ b/lib/Hack.io/Hack.io.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.5" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates a handful of Nuget packages — 4 in total. ImageSharp had a vulnerability that necessitated an upgrade; the other 3 were standard updates.