### PR TITLE
Cleanup attributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,25 @@
 root = true
 
 [*]
+charset = utf-8
+end_of_line = lf
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.{sln,csproj}]
 end_of_line = crlf
+charset = utf-8-bom
+
+[*.sln]
+indent_style = tab
+
+[*.csproj]
+indent_style = space
+indent_size = 2
 
 [*.cs]
+indent_size = 4
 csharp_style_var_elsewhere = false:none
 csharp_style_var_for_built_in_types = false:suggestion
 csharp_style_var_when_type_is_apparent = false:suggestion
@@ -21,10 +34,6 @@ csharp_style_expression_bodied_lambdas = when_on_single_line:suggestion
 csharp_style_expression_bodied_local_functions = when_on_single_line:suggestion
 csharp_new_line_before_open_brace = all
 csharp_style_unused_value_assignment_preference = unused_local_variable:suggestion
-
-[*.{cs,vb}]
-indent_size = 4
-tab_width = 4
 
 # IDE0058: Expression value is never used
 dotnet_diagnostic.IDE0058.severity = none

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
-*           text=auto
+*           text=auto eol=lf
 
 # Source files
 *.cs        text diff=csharp

--- a/DolphinTextureExtraction tool.sln
+++ b/DolphinTextureExtraction tool.sln
@@ -15,17 +15,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuroraLib", "lib\AuroraLip\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AFSLib", "lib\AFSLib\AFSLib.csproj", "{09C23352-8261-447B-9BB5-4C82DAF3CFFD}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Configure Solution", "Configure Solution", "{7975F61B-A37D-4B44-A3ED-B4F19099BB90}"
-	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
-	EndProjectSection
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmark", "Benchmark\Benchmark.csproj", "{6D800FCD-CA7C-4A27-8177-2665332AA70F}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{ADDD238A-40A0-49C3-9DA9-F897E8E6FBDD}"
-	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Eliminated potential encoding/eol conflicts by adding explicit `utf-8`/`lf` formatting to all files. The only exceptions are `.sln`/`.csproj` files, which use `utf-8-bom`/`crlf` instead. Also removed `.editorconfig` reference from solution (which was duplicated for some reason?), as it's not actually needed to apply changes to files.