### PR TITLE
Update Packages - ImageSharp vulnerability… Again!

### DIFF
--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TextureExtraction tool/DolphinTextureExtraction tool.csproj
+++ b/TextureExtraction tool/DolphinTextureExtraction tool.csproj
@@ -40,7 +40,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/lib/AuroraLip/Archives/Formats/ALAR.cs
+++ b/lib/AuroraLip/Archives/Formats/ALAR.cs
@@ -75,7 +75,7 @@ namespace AuroraLib.Archives.Formats
                         offset = source.ReadUInt32(Endian.Big);
                         size = source.ReadUInt32(Endian.Big);
                         lixo = source.ReadString(6);
-                        path = source.ReadString();
+                        path = source.ReadCString();
                         name = Path.GetFileName(path);
 
                         Stream data = new SubStream(source, size, offset);

--- a/lib/AuroraLip/Archives/Formats/ARC_Pit.cs
+++ b/lib/AuroraLip/Archives/Formats/ARC_Pit.cs
@@ -57,7 +57,7 @@ namespace AuroraLib.Archives.Formats
                 uint CRC = source.ReadUInt32(endian);
                 uint Offset = source.ReadUInt32(endian);
                 uint Size = source.ReadUInt32(endian);
-                string Name = source.ReadString();
+                string Name = source.ReadCString();
                 long Timestamp = source.ReadInt64(endian);
                 Add(new FileNode(Name, new SubStream(source, Size, Offset)));
             }
@@ -97,7 +97,7 @@ namespace AuroraLib.Archives.Formats
                 internal ArchiveInfo(Stream stream, Offset offset, Endian endian)
                 {
                     stream.Seek(offset.NameOffsets, SeekOrigin.Begin);
-                    string Name = stream.ReadString();
+                    string Name = stream.ReadCString();
                     stream.Seek(offset.InfoOffsets, SeekOrigin.Begin);
                     uint filesCount = stream.ReadUInt32(endian);
                     for (int i = 0; i < filesCount; i++)

--- a/lib/AuroraLip/Archives/Formats/Asura.cs
+++ b/lib/AuroraLip/Archives/Formats/Asura.cs
@@ -51,7 +51,7 @@ namespace AuroraLib.Archives.Formats
                 if (nameoffset != -1)
                 {
                     source.Seek(startpos + nameoffset, SeekOrigin.Begin);
-                    string name = source.ReadString().TrimStart('\\');
+                    string name = source.ReadCString().TrimStart('\\');
 
                     if (magic == "FCSR")
                     {

--- a/lib/AuroraLip/Archives/Formats/FSYS.cs
+++ b/lib/AuroraLip/Archives/Formats/FSYS.cs
@@ -43,7 +43,7 @@ namespace AuroraLib.Archives.Formats
             source.Read(FileInfosOffsets.Span, Endian.Big);
 
             source.Seek(header.StringTableOffset, SeekOrigin.Begin);
-            string[] Filenames = source.For((int)header.Entries, s => s.ReadString());
+            string[] Filenames = source.For((int)header.Entries, s => s.ReadCString());
 
             for (int i = 0; i < FileInfosOffsets.Length; i++)
             {

--- a/lib/AuroraLip/Archives/Formats/NARC.cs
+++ b/lib/AuroraLip/Archives/Formats/NARC.cs
@@ -45,7 +45,7 @@ namespace AuroraLib.Archives.Formats
             foreach (NARCEntry entry in entries)
             {
                 source.Position = nameTableOffset + entry.NameOffset;
-                FileNode Sub = new(source.ReadString(), new SubStream(source, entry.DataSize, dataTableOffset + entry.DataOffset));
+                FileNode Sub = new(source.ReadCString(), new SubStream(source, entry.DataSize, dataTableOffset + entry.DataOffset));
                 Add(Sub);
             }
         }

--- a/lib/AuroraLip/Archives/Formats/NEP.cs
+++ b/lib/AuroraLip/Archives/Formats/NEP.cs
@@ -30,7 +30,7 @@ namespace AuroraLib.Archives.Formats
             {
                 long pos = source.Position;
                 Entry entry = source.Read<Entry>(Endian.Big);
-                string name = source.ReadString();
+                string name = source.ReadCString();
                 name = name.Replace("..\\", string.Empty);
                 if (!Contains(name))
                 {

--- a/lib/AuroraLip/Archives/Formats/NLCM.cs
+++ b/lib/AuroraLip/Archives/Formats/NLCM.cs
@@ -41,7 +41,7 @@ namespace AuroraLib.Archives.Formats
             uint unknown2 = source.ReadUInt32(Endian.Big);
             uint file_count = source.ReadUInt32(Endian.Big);
             uint unknown3 = source.ReadUInt32(Endian.Big);
-            string reference_file = source.ReadString();
+            string reference_file = source.ReadCString();
             source.Seek(table_offset, SeekOrigin.Begin);
 
             //try to request an external file.

--- a/lib/AuroraLip/Archives/Formats/Nintendo/Bres.cs
+++ b/lib/AuroraLip/Archives/Formats/Nintendo/Bres.cs
@@ -83,7 +83,7 @@ namespace AuroraLib.Archives.Formats.Nintendo
                 if (group.NameOffset != 0)
                 {
                     source.Seek(StartOfGroup + group.NameOffset, SeekOrigin.Begin);
-                    string Name = source.ReadString();
+                    string Name = source.ReadCString();
 
                     if (group.DataOffset != 0)
                     {

--- a/lib/AuroraLip/Archives/Formats/Nintendo/RARC.cs
+++ b/lib/AuroraLip/Archives/Formats/Nintendo/RARC.cs
@@ -72,7 +72,7 @@ namespace AuroraLib.Archives.Formats.Nintendo
             foreach (DirectoryT dir in directories)
             {
                 source.Seek(stringTableOffset + dir.NameOffset, SeekOrigin.Begin);
-                string name = source.ReadString();
+                string name = source.ReadCString();
 
                 DirectoryNode currentNode;
                 if (dir.Type == 1414483794) // is ROOT
@@ -88,7 +88,7 @@ namespace AuroraLib.Archives.Formats.Nintendo
                 for (int n = (int)dir.FirstFileOffset; n < dir.FileCount + dir.FirstFileOffset; n++)
                 {
                     source.Seek(stringTableOffset + files[n].NameOffset, SeekOrigin.Begin);
-                    name = source.ReadString();
+                    name = source.ReadCString();
 
                     if (files[n].Attribute == FileAttribute.DIRECTORY) //IsDirectory
                     {
@@ -224,7 +224,7 @@ namespace AuroraLib.Archives.Formats.Nintendo
             List<FileNode> fileDVD = new();
 
             // MRAM + sorting
-            Yaz0 yaz = new() { LookAhead = false, ExplicitOrder = Endian.Big };
+            Yaz0 yaz = new() { LookAhead = false, FormatByteOrder = Endian.Big };
             foreach (FileNode fileNode in GetAllValuesOf<FileNode>())
             {
                 if (fileNode.Properties.Contains("YAZ0") && !fileNode.Data.At(0, s => s.Match("Yaz0")))

--- a/lib/AuroraLip/Archives/Formats/Nintendo/U8.cs
+++ b/lib/AuroraLip/Archives/Formats/Nintendo/U8.cs
@@ -51,7 +51,7 @@ namespace AuroraLib.Archives.Formats.Nintendo
             {
                 U8Node node = nodes[i];
                 source.Seek(StringTableOffset + node.NameOffset, SeekOrigin.Begin);
-                string name = source.ReadString();
+                string name = source.ReadCString();
 
                 //if there is already an ellement with the names.
                 if (stack.Peek().Item1.Contains(name))

--- a/lib/AuroraLip/Archives/Formats/PAC.cs
+++ b/lib/AuroraLip/Archives/Formats/PAC.cs
@@ -43,7 +43,7 @@ namespace AuroraLib.Archives.Formats
                 foreach (var entry in entries)
                 {
                     streamPAH.Seek(entry.NameOffset, SeekOrigin.Begin);
-                    string name = streamPAH.ReadString();
+                    string name = streamPAH.ReadCString();
                     FileNode file = new(name, new SubStream(source, entry.Size, entry.Offset));
                     Add(file);
                 }

--- a/lib/AuroraLip/Archives/Formats/PAK_FE.cs
+++ b/lib/AuroraLip/Archives/Formats/PAK_FE.cs
@@ -44,7 +44,7 @@ namespace AuroraLib.Archives.Formats
             for (int i = 0; i < NrEntries; i++)
             {
                 source.Seek(entries[i].name, SeekOrigin.Begin);
-                string name = source.ReadString();
+                string name = source.ReadCString();
 
                 FileNode file = new(name, new SubStream(source, entries[i].size, entries[i].data));
                 Add(file);

--- a/lib/AuroraLip/Archives/Formats/PAK_JPS.cs
+++ b/lib/AuroraLip/Archives/Formats/PAK_JPS.cs
@@ -56,7 +56,7 @@ namespace AuroraLib.Archives.Formats
 
                 long pos = source.Position;
                 source.Seek(string_table_position + file_name_offset, SeekOrigin.Begin);
-                string file_name = source.ReadString();
+                string file_name = source.ReadCString();
 
                 if (!Contains(file_name))
                 {

--- a/lib/AuroraLip/Archives/Formats/PAK_RetroWii.cs
+++ b/lib/AuroraLip/Archives/Formats/PAK_RetroWii.cs
@@ -148,7 +148,7 @@ namespace AuroraLib.Archives.Formats.Retro
 
             public NameEntry(Stream stream)
             {
-                Name = stream.ReadString();
+                Name = stream.ReadCString();
                 Type = stream.ReadString(4);
                 ID = stream.ReadUInt64(Endian.Big);
             }

--- a/lib/AuroraLip/Archives/Formats/PK_AQ.cs
+++ b/lib/AuroraLip/Archives/Formats/PK_AQ.cs
@@ -89,7 +89,7 @@ namespace AuroraLib.Archives.Formats
                     if (directories[i].ParentIndex != -1)
                     {
                         fsStream.Seek(nameTabelPos + directoryNameOffsets[i], SeekOrigin.Begin);
-                        string name = fsStream.ReadString();
+                        string name = fsStream.ReadCString();
                         dir = new(name);
                         directoryPairs[dirEntry.ParentIndex].Add(dir);
                     }
@@ -100,7 +100,7 @@ namespace AuroraLib.Archives.Formats
                     {
                         int FileIndex = dirEntry.FileStartChild + fi;
                         fsStream.Seek(nameTabelPos + fileNameOffsets[FileIndex], SeekOrigin.Begin);
-                        string filename = fsStream.ReadString();
+                        string filename = fsStream.ReadCString();
                         string filePath = Path.Combine(Path.GetRelativePath(rootPath, dir.GetFullPath()), filename).Replace('\\', '/').ToLower().Replace('?', 'L');
                         //Get CRC32
                         crc32.Reset();

--- a/lib/AuroraLip/Archives/Formats/POD5.cs
+++ b/lib/AuroraLip/Archives/Formats/POD5.cs
@@ -58,7 +58,7 @@ namespace AuroraLib.Archives.Formats
                 long SavedPosition = source.Position;
 
                 source.Seek(NameOffsetForFile + StringTableOffset, SeekOrigin.Begin);
-                string Name = source.ReadString();
+                string Name = source.ReadCString();
 
                 //If Duplicate...
                 if (Contains(Name))

--- a/lib/AuroraLip/Archives/Formats/RKV2.cs
+++ b/lib/AuroraLip/Archives/Formats/RKV2.cs
@@ -54,7 +54,7 @@ namespace AuroraLib.Archives.Formats
                 long FilePosition = source.Position;
 
                 source.Seek(NameOffsetForFile + NameOffset, SeekOrigin.Begin);
-                string Name = source.ReadString();
+                string Name = source.ReadCString();
 
                 FileNode Sub = new(Name, new SubStream(source, SizeForFile, OffsetForFile));
                 //If Duplicate...

--- a/lib/AuroraLip/Archives/Formats/ShrekDir.cs
+++ b/lib/AuroraLip/Archives/Formats/ShrekDir.cs
@@ -90,7 +90,7 @@ namespace AuroraLib.Archives.Formats
                 Offset = stream.ReadUInt32(endian);
                 DecompSize = stream.ReadUInt32(endian);
                 CompSize = stream.ReadUInt32(endian);
-                Name = stream.ReadString();
+                Name = stream.ReadCString();
                 stream.Align(4);
             }
         }

--- a/lib/AuroraLip/AuroraLib.csproj
+++ b/lib/AuroraLip/AuroraLib.csproj
@@ -24,12 +24,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AuroraLib.Compression" Version="1.1.1" />
-    <PackageReference Include="AuroraLib.Cryptography" Version="1.1.0" />
+    <PackageReference Include="AuroraLib.Compression" Version="1.2.1" />
+    <PackageReference Include="AuroraLib.Cryptography" Version="1.1.0.1" />
     <PackageReference Include="HashDepot" Version="3.1.0" />
-    <PackageReference Include="RenderWareNET" Version="0.6.2" />
+    <PackageReference Include="RenderWareNET" Version="0.6.3" />
     <PackageReference Include="SevenZipExtractor" Version="1.0.17" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageReference Include="ZstdSharp.Port" Version="0.8.1" />
   </ItemGroup>
 

--- a/lib/AuroraLip/DiscImage/Dolphin/FSTBin.cs
+++ b/lib/AuroraLip/DiscImage/Dolphin/FSTBin.cs
@@ -25,7 +25,7 @@ namespace AuroraLib.DiscImage.Dolphin
             while (i < l)
             {
                 stream.Seek(stringTableOffset + (int)Entires[i].NameOffset, SeekOrigin.Begin);
-                string name = stream.ReadString();
+                string name = stream.ReadCString();
                 if (Entires[i].IsDirectory)
                 {
                     DirectoryNode subdir = new(name);

--- a/lib/AuroraLip/DiscImage/Dolphin/GameID.cs
+++ b/lib/AuroraLip/DiscImage/Dolphin/GameID.cs
@@ -88,13 +88,13 @@ namespace AuroraLib.DiscImage.Dolphin
         [DebuggerStepThrough]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string GetString()
-            => EncodingX.GetString(AsSpan(), 0x0);
+            => EncodingX.GetCString(AsSpan());
 
         /// <inheritdoc />
         [DebuggerStepThrough]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string GetString(Encoding encoding)
-            => EncodingX.GetString(AsSpan(), encoding, 0x0);
+            => EncodingX.GetCString(AsSpan(), encoding);
 
         /// <inheritdoc />
         public bool Equals(string other) => other == GetString();

--- a/lib/AuroraLip/Texture/Formats/HALDAT.cs
+++ b/lib/AuroraLip/Texture/Formats/HALDAT.cs
@@ -99,7 +99,7 @@ namespace AuroraLib.Texture.Formats
                 uint symbol_offset = stream.ReadUInt32(Endian.Big);
                 long prevPosition = stream.Position;
                 stream.Seek(base_symbol_name_offset + symbol_offset, SeekOrigin.Begin);
-                string symbol_name = stream.ReadString();
+                string symbol_name = stream.ReadCString();
                 dict.Add(symbol_name, data_offset);
                 stream.Seek(prevPosition, SeekOrigin.Begin);
             }
@@ -245,7 +245,7 @@ namespace AuroraLib.Texture.Formats
                     return GetClassFromName<T>(null, default_class_name);
 
                 stream.Seek(class_name_offset, SeekOrigin.Begin);
-                string class_name = stream.ReadString();
+                string class_name = stream.ReadCString();
                 return GetClassFromName<T>(class_name, default_class_name);
             }
 

--- a/lib/AuroraLip/Texture/Formats/HSF.cs
+++ b/lib/AuroraLip/Texture/Formats/HSF.cs
@@ -33,7 +33,7 @@ namespace AuroraLib.Texture.Formats
 
             for (int i = 0; i < texInfos.Length; i++)
             {
-                string textureName = stream.At(header.StringTable.Offset + texInfos[i].NameOffset, S => S.ReadString());
+                string textureName = stream.At(header.StringTable.Offset + texInfos[i].NameOffset, S => S.ReadCString());
                 GXImageFormat format = texInfos[i].GetGXImageFormat();
                 GXPaletteFormat paletteFormat = texInfos[i].GetGXPaletteFormat();
 

--- a/lib/AuroraLip/Texture/Formats/LFXT.cs
+++ b/lib/AuroraLip/Texture/Formats/LFXT.cs
@@ -18,14 +18,14 @@ namespace AuroraLib.Texture.Formats
         private static readonly Identifier32 _identifier = new("LFXT");
 
         public bool IsMatch(Stream stream, ReadOnlySpan<char> extension = default)
-            => stream.Length > 0x30 && stream.Match(_identifier) && stream.ReadString().Length > 3;
+            => stream.Length > 0x30 && stream.Match(_identifier) && stream.ReadCString().Length > 3;
 
         protected override void Read(Stream stream)
         {
             // NOTE: non-Nintendo consoles (PS2, XBox, PC) have the TXFL magic and use Little Endian
             // but that is out of scope for DTE
             stream.MatchThrow(_identifier);
-            string _Name = stream.ReadString();
+            string _Name = stream.ReadCString();
             var Properties = stream.Read<HeaderProperties>(Endian.Big);
 
             //To GXFormat

--- a/lib/AuroraLip/Texture/Formats/REFT.cs
+++ b/lib/AuroraLip/Texture/Formats/REFT.cs
@@ -52,7 +52,7 @@ namespace AuroraLib.Texture.Formats
             uint Unknown2 = stream.ReadUInt32(ByteOrder);
             ushort NameLength = stream.ReadUInt16(ByteOrder);
             ushort Unknown3 = stream.ReadUInt16(ByteOrder);
-            string Name = stream.ReadString();
+            string Name = stream.ReadCString();
             stream.Position = SubfilePosition;
 #if DEBUG
             if (Unknown != 0 || Unknown2 != 0 || Unknown3 != 0)

--- a/lib/AuroraLip/Texture/J3D/NameTableIO.cs
+++ b/lib/AuroraLip/Texture/J3D/NameTableIO.cs
@@ -24,7 +24,7 @@
                 long saveReaderPos = stream.Position;
                 stream.Position = offset + nameOffset;
 
-                names.Add(stream.ReadString());
+                names.Add(stream.ReadCString());
 
                 stream.Position = saveReaderPos;
             }

--- a/lib/Hack.io/Content/BMD.JNT1.cs
+++ b/lib/Hack.io/Content/BMD.JNT1.cs
@@ -1,4 +1,4 @@
-﻿using AuroraLib.Core.Exceptions;
+using AuroraLib.Core.Exceptions;
 using AuroraLib.Texture.J3D;
 using OpenTK.Mathematics;
 
@@ -42,7 +42,7 @@ namespace Hack.io
                     long saveReaderPos = stream.Position;
                     stream.Position = ChunkStart + nameTableOffset + nameOffset;
 
-                    names.Add(stream.ReadString());
+                    names.Add(stream.ReadCString());
 
                     stream.Position = saveReaderPos;
                 }

--- a/lib/Hack.io/Content/BMD.MAT3.cs
+++ b/lib/Hack.io/Content/BMD.MAT3.cs
@@ -175,7 +175,7 @@ namespace Hack.io
                                 long saveReaderPos = stream.Position;
                                 stream.Position = ChunkStart + sectionOffset + nameOffset;
 
-                                m_MaterialNames.Add(stream.ReadString());
+                                m_MaterialNames.Add(stream.ReadCString());
 
                                 stream.Position = saveReaderPos;
                             }

--- a/lib/Hack.io/Content/BMD.TEX1.cs
+++ b/lib/Hack.io/Content/BMD.TEX1.cs
@@ -123,7 +123,7 @@ namespace Hack.io
                     long saveReaderPos = stream.Position;
                     stream.Position = ChunkStart + textureNameTableOffset + nameOffset;
 
-                    names.Add(stream.ReadString());
+                    names.Add(stream.ReadCString());
 
                     stream.Position = saveReaderPos;
                 }


### PR DESCRIPTION
Updates all relevant packages now that ImageSharp has a vulnerability. Unlike last time[^1], further tweaks needed to be made to account for changes in `AuroraLib.Core` & `AuroraLib.Compression`

[^1]: #62