### PR TITLE
Bump TargetFramework to net8.0

### DIFF
--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Additionally, the tool supports unpacking all compatible formats and some other 
 Although the most common formats are already supported, the tool is still under development and new functions and other formats will be added over time.
 
 ## Download
-This is a .NET 6.0 application and requires the .NET Runtime 6.0. If you don't have it installed yet, you can download it from [here](https://dotnet.microsoft.com/en-us/download/dotnet/6.0).
+This is a .NET 8.0 application and requires the .NET Runtime 8.0. If you don't have it installed yet, you can download it from [here](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).
 
 [<img src="https://img.shields.io/github/v/release/Venomalia/DolphinTextureExtraction-tool?style=for-the-badge" alt="Release Download" height="34"/>](https://github.com/Venomalia/DolphinTextureExtraction-tool/releases/latest)
 

--- a/TextureExtraction tool/DolphinTextureExtraction tool.csproj
+++ b/TextureExtraction tool/DolphinTextureExtraction tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ProjectGuid>{89776DB8-07A1-4B36-BE77-7AB5E4237E3A}</ProjectGuid>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
@@ -22,24 +22,20 @@
     <Title>Dolphin Texture Extraction Tool</Title>
     <Authors>Venomalia</Authors>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
+    <WeaverConfiguration>
+      <Weavers>
+        <Costura />
+      </Weavers>
+    </WeaverConfiguration>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
-  </PropertyGroup>
   <ItemGroup>
     <Content Include="Icon.ico" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Costura.Fody" Version="5.8.0-alpha0098">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Costura.Fody" Version="6.0.0-beta0000" PrivateAssets="all" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
   </ItemGroup>
 

--- a/lib/AFSLib/AFSLib.csproj
+++ b/lib/AFSLib/AFSLib.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ProjectGuid>{09C23352-8261-447B-9BB5-4C82DAF3CFFD}</ProjectGuid>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>

--- a/lib/AuroraLip/Archives/Formats/BIN_MP.cs
+++ b/lib/AuroraLip/Archives/Formats/BIN_MP.cs
@@ -109,7 +109,7 @@ namespace AuroraLib.Archives.Formats
                     case CompressionType.FSLIDE:
                         uint temp_len = source.ReadUInt32(Endian.Big);
                         DeStream = new MemoryPoolStream((int)DeSize);
-                        LZHudson.DecompressHeaderless(source, DeStream, (int)DeSize);
+                        LZHudson.DecompressHeaderless(source, DeStream, DeSize);
                         break;
 
                     case CompressionType.RLE:

--- a/lib/AuroraLip/AuroraLib.csproj
+++ b/lib/AuroraLip/AuroraLib.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ProjectGuid>{CE629181-0090-46D0-81BC-16682E497573}</ProjectGuid>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
@@ -24,10 +24,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AuroraLib.Compression" Version="1.2.1" />
-    <PackageReference Include="AuroraLib.Cryptography" Version="1.1.0.1" />
+    <PackageReference Include="AuroraLib.Compression" Version="1.3.0.1" />
+    <PackageReference Include="AuroraLib.Cryptography" Version="1.2.0" />
     <PackageReference Include="HashDepot" Version="3.1.0" />
-    <PackageReference Include="RenderWareNET" Version="0.6.3" />
+    <PackageReference Include="RenderWareNET" Version="0.6.4" />
     <PackageReference Include="SevenZipExtractor" Version="1.0.17" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageReference Include="ZstdSharp.Port" Version="0.8.1" />
@@ -42,5 +42,5 @@
     <Using Include="AuroraLib.Core" />
     <Using Include="AuroraLib.Core.IO" />
   </ItemGroup>
-  
+
 </Project>

--- a/lib/AuroraLip/Common/Exceptions.cs
+++ b/lib/AuroraLip/Common/Exceptions.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace AuroraLib.Common
 {
@@ -17,6 +17,7 @@ namespace AuroraLib.Common
         {
         }
 
+        [Obsolete(DiagnosticId = "SYSLIB0051")]
         protected PaletteException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/lib/Hack.io/Hack.io.csproj
+++ b/lib/Hack.io/Hack.io.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ProjectGuid>{CD2CA20A-E6AD-4B1E-9D04-FB98970B61D5}</ProjectGuid>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>

--- a/lib/LibCPK/LibCPK.csproj
+++ b/lib/LibCPK/LibCPK.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ProjectGuid>{BA3A00E4-4F51-4AB4-A8FB-F4B64A874449}</ProjectGuid>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>


### PR DESCRIPTION
.NET 6 is slated to reach eol on the 12th[^1], so this PR bumps us to the newest LTS: .NET 8

A handful of adjustments had to be made, some of which might be a result of `AuroraLib.Compression` getting bumped to 1.3.0 while updating the NuGet packages:
- `LZHudson.DecompressHeaderless` argument `decomLength` now uses `uint` instead of `int`. Might be a bug, as other `DecompressHeaderless` functions accept `int` for their argument type
- ~~`ExceptListT` has to specify `Cryptography.UInt128` for its `Hash` variable, as that would otherwise conflict with new C# struct of the same name[^2]. Future .NET8+ builds of Cryptography should exclude that type entirely~~ Fixed!
- ~~`SpanEx.Count` had to be explicitly called, as the extension version now clashes with an official equivalent added to `MemoryExtensions`[^3]. Like the above, .NET8+ builds of Core should exclude those functions, though I'd give that class a more thorough pass to make sure other functions aren't overlapping as well (eg: `IndexOf` also conflicts)~~ Fixed!
- `PaletteException` legacy constructor given an obsolete attribute

[^1]: https://devblogs.microsoft.com/dotnet/dotnet-6-end-of-support/
[^2]: https://learn.microsoft.com/en-us/dotnet/api/system.uint128?view=net-8.0
[^3]: https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.count?view=net-8.0#system-memoryextensions-count-1(system-readonlyspan((-0))-0)