### PR TITLE
Support compression: none for RVZ

### DIFF
--- a/TextureExtraction tool/DolphinTextureExtraction tool.csproj
+++ b/TextureExtraction tool/DolphinTextureExtraction tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ProjectGuid>{89776DB8-07A1-4B36-BE77-7AB5E4237E3A}</ProjectGuid>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>

--- a/lib/AuroraLip/Compression/Algorithms/None.cs
+++ b/lib/AuroraLip/Compression/Algorithms/None.cs
@@ -1,0 +1,25 @@
+using AuroraLib.Compression.Interfaces;
+using System.IO.Compression;
+
+namespace AuroraLib.Compression.Algorithms
+{
+    public class None : ICompressionAlgorithm
+    {
+        public bool IsMatch(Stream stream, ReadOnlySpan<char> extension = default) => true;
+
+        public void Compress(ReadOnlySpan<byte> source, Stream destination, CompressionLevel level = CompressionLevel.Optimal)
+        {
+            Compress(source, destination, 0);
+        }
+
+        public static void Compress(ReadOnlySpan<byte> source, Stream destination, int level)
+        {
+            destination.Write(source);
+        }
+
+        public void Decompress(Stream source, Stream destination)
+        {
+            source.CopyTo(destination);
+        }
+    }
+}

--- a/lib/AuroraLip/DiscImage/RVZ/DiscT.cs
+++ b/lib/AuroraLip/DiscImage/RVZ/DiscT.cs
@@ -31,11 +31,13 @@ namespace AuroraLib.DiscImage.RVZ
 
         public ICompressionDecoder GetDecoder() => Compression switch
         {
+            CompressionTypes.None => new None(),
             CompressionTypes.Zstandard => new Zstd(),
             _ => throw new NotImplementedException($"{Compression} compression is currently not supported."),
         };
         public ICompressionEncoder GetEncoder() => Compression switch
         {
+            CompressionTypes.None => new None(),
             CompressionTypes.Zstandard => new Zstd(),
             _ => throw new NotImplementedException(),
         };


### PR DESCRIPTION
I had a couple RVZ images that were not zlib compressed, so this adds support for uncompressed RVZ images.  The tool worked fine after that!

I also bumped to .NET 10. I can split into 2 PRs if you aren't ready for that, yet.